### PR TITLE
feature: add option arg raw for unescape_uri, get_uri_args

### DIFF
--- a/lib/resty/core/uri.lua
+++ b/lib/resty/core/uri.lua
@@ -24,8 +24,8 @@ ffi.cdef[[
     void ngx_http_lua_ffi_escape_uri(const unsigned char *src, size_t len,
                                      unsigned char *dst);
 
-    size_t ngx_http_lua_ffi_unescape_uri(const unsigned char *src,
-                                         size_t len, unsigned char *dst);
+    size_t ngx_http_lua_ffi_unescape_uri(const unsigned char *src, size_t len,
+                                         unsigned char *dst, int raw);
 ]]
 
 
@@ -49,7 +49,7 @@ ngx.escape_uri = function (s)
 end
 
 
-ngx.unescape_uri = function (s)
+ngx.unescape_uri = function (s, raw)
     if type(s) ~= 'string' then
         if not s then
             s = ''
@@ -57,10 +57,17 @@ ngx.unescape_uri = function (s)
             s = tostring(s)
         end
     end
+
+    if not raw then
+        raw = 0
+    else
+        raw = 1
+    end
+
     local slen = #s
     local dlen = slen
     local dst = get_string_buf(dlen)
-    dlen = C.ngx_http_lua_ffi_unescape_uri(s, slen, dst)
+    dlen = C.ngx_http_lua_ffi_unescape_uri(s, slen, dst, raw)
     return ffi_string(dst, dlen)
 end
 

--- a/t/uri.t
+++ b/t/uri.t
@@ -260,3 +260,49 @@ qr/\[TRACE   \d+ content_by_lua:3 loop\]/
 --- no_error_log
 [error]
 
+
+
+=== TEST 11: unescape_uri (string) raw is not set
+--- http_config eval: $::HttpConfig
+--- config
+    location = /uri {
+        content_by_lua '
+            local s
+            for i = 1, 100 do
+                s = ngx.unescape_uri("hello+%20world")
+            end
+            ngx.say(s)
+        ';
+    }
+--- request
+GET /uri
+--- response_body
+hello  world
+--- error_log eval
+qr/\[TRACE   \d+ content_by_lua:3 loop\]/
+--- no_error_log
+[error]
+
+
+
+=== TEST 12: unescape_uri (string) raw is true
+--- http_config eval: $::HttpConfig
+--- config
+    location = /uri {
+        content_by_lua '
+            local s
+            for i = 1, 100 do
+                s = ngx.unescape_uri("hello+%20world", true)
+            end
+            ngx.say(s)
+        ';
+    }
+--- request
+GET /uri
+--- response_body
+hello+ world
+--- error_log eval
+qr/\[TRACE   \d+ content_by_lua:3 loop\]/
+--- no_error_log
+[error]
+


### PR DESCRIPTION
do not decode '+' to ' ' when option raw is true

according to rfc1738, '+' is reserved characters

may be we can add the option arg, just like: urldecode, rawurldeocde in PHP :)
