### PR TITLE
Adding missing link in table of contents for ngx.ssl

### DIFF
--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -14,6 +14,7 @@ Table of Contents
     * [clear_certs](#clear_certs)
     * [cert_pem_to_der](#cert_pem_to_der)
     * [set_der_cert](#set_der_cert)
+    * [priv_key_pem_to_der](#priv_key_pem_to_der)
     * [set_der_priv_key](#set_der_priv_key)
     * [server_name](#server_name)
     * [raw_server_addr](#raw_server_addr)


### PR DESCRIPTION
I noticed this new function, but had a hard time finding it in the doc because it was missing from the table of contents.