### PR TITLE
Unmatched capture are set to false in capture table

### DIFF
--- a/t/re-match.t
+++ b/t/re-match.t
@@ -439,3 +439,105 @@ NYI
 --- error_log eval
 qr/\[TRACE\s+\d+\s+/
 
+
+
+=== TEST 11: unmatched captures are false
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua '
+            local m = ngx.re.match("hello!", "(hello)(, .+)?(!)", "jo")
+
+            if m then
+                ngx.say(m[0])
+                ngx.say(m[1])
+                ngx.say(m[2])
+                ngx.say(m[3])
+            else
+                ngx.say("not matched!")
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+hello!
+hello
+false
+!
+--- no_error_log
+[error]
+NYI
+--- error_log eval
+qr/\[TRACE\s+\d+\s+/
+
+
+
+=== TEST 12: unmatched trailing captures are false
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua '
+            local m = ngx.re.match("hello", "(hello)(, .+)?(!)?", "jo")
+
+            if m then
+                ngx.say(m[0])
+                ngx.say(m[1])
+                ngx.say(m[2])
+                ngx.say(m[3])
+            else
+                ngx.say("not matched!")
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+hello
+hello
+false
+false
+--- no_error_log
+[error]
+NYI
+--- error_log eval
+qr/\[TRACE\s+\d+\s+/
+
+
+
+=== TEST 13: unmatched named captures are false
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua '
+            local m = ngx.re.match("hello!", "(?<first>hello)(?<second>, .+)?(?<third>!)", "jo")
+
+            if m then
+                ngx.say(m[0])
+                ngx.say(m[1])
+                ngx.say(m[2])
+                ngx.say(m[3])
+                ngx.say(m.first)
+                ngx.say(m.second)
+                ngx.say(m.third)
+            else
+                ngx.say("not matched!")
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+hello!
+hello
+false
+!
+hello
+false
+!
+--- no_error_log
+[error]
+NYI
+--- error_log eval
+qr/\[TRACE\s+\d+\s+/
+


### PR DESCRIPTION
This PR reflect the changes made in lua-nginx-module by https://github.com/openresty/lua-nginx-module/pull/653.

Now unmatched capture groups in `ngx.re.match` and `ngx.re.gmatch` are
set to `false` rather than nil. This prevents to create table with
holes that don't play nice with `ipairs` or `#` operators.

For consistency, unmatched trailing captures (for instance in
`ngx.re.match("hello", "(hello)(.+)?")`) as well as named captures are
also set to `false`.