### PR TITLE
Caste various regex params to string to avoid thread abort

### DIFF
--- a/lib/resty/core/regex.lua
+++ b/lib/resty/core/regex.lua
@@ -353,6 +353,11 @@ end
 
 
 local function re_match_helper(subj, regex, opts, ctx, want_caps, res, nth)
+    -- we need to caste these to a string to avoid a potential thread abort
+    -- see http://bit.ly/1SH0oz6
+    regex = tostring(regex)
+    subj  = tostring(subj)
+
     local compiled, compile_once, flags = re_match_compile(regex, opts)
     if compiled == nil then
         -- compiled_once holds the error string
@@ -528,6 +533,8 @@ local function re_sub_compile(regex, opts, replace, func)
         -- print("compiled regex not found, compiling regex...")
         local errbuf = get_string_buf(MAX_ERR_MSG_LEN)
 
+        regex = tostring(regex)
+
         compiled = C.ngx_http_lua_ffi_compile_regex(regex, #regex, flags,
                                                     pcre_opts, errbuf,
                                                     MAX_ERR_MSG_LEN)
@@ -602,6 +609,7 @@ local function re_sub_func_helper(subj, regex, replace, opts, global)
 
     -- exec the compiled regex
 
+    subj = tostring(subj)
     local subj_len = #subj
     local count = 0
     local pos = 0
@@ -645,7 +653,7 @@ local function re_sub_func_helper(subj, regex, replace, opts, global)
 
         local res = collect_captures(compiled, rc, subj, flags)
 
-        local bit = replace(res)
+        local bit = tostring(replace(res))
         local bit_len = #bit
 
         local new_dst_len = dst_len + prefix_len + bit_len
@@ -711,6 +719,7 @@ local function re_sub_str_helper(subj, regex, replace, opts, global)
 
     -- exec the compiled regex
 
+    subj = tostring(subj)
     local subj_len = #subj
     local count = 0
     local pos = 0

--- a/t/re-match.t
+++ b/t/re-match.t
@@ -9,7 +9,7 @@ use Cwd qw(cwd);
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 5 + 3);
+plan tests => repeat_each() * (blocks() * 5 + 1);
 
 my $pwd = cwd();
 
@@ -540,4 +540,50 @@ false
 NYI
 --- error_log eval
 qr/\[TRACE\s+\d+\s+/
+
+=== TEST 14: subject is not a string type
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua '
+            local m = ngx.re.match(12345, [=[(\\d+)]=], "jo")
+
+            if m then
+                ngx.say(m[0])
+                ngx.say(m[1])
+            else
+                ngx.say("not matched")
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+12345
+12345
+--- no_error_log
+[error]
+attempt to get length of local 'subj' (a number value)
+
+=== TEST 15: regex is not a string type
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua '
+            local m = ngx.re.match(12345, 123, "jo")
+
+            if m then
+                ngx.say(m[0])
+            else
+                ngx.say("not matched")
+            end
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+123
+--- no_error_log
+[error]
+attempt to get length of local 'regex' (a number value)
 

--- a/t/re-sub.t
+++ b/t/re-sub.t
@@ -326,3 +326,42 @@ GET /t
 bad argument type
 NYI
 
+=== TEST 8: string replace subj is not a string type
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua '
+			local newstr, n, err = ngx.re.sub(1234, "([0-9])[0-9]", 5, "jo")
+
+			ngx.say(newstr)
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+534
+--- no_error_log
+[error]
+attempt to get length of local 'subj' (a number value)
+
+=== TEST 9: func replace return is not a string type
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua '
+			local lookup = function(m)
+				-- note we are returning a number type here
+				return 5
+			end
+
+			local newstr, n, err = ngx.re.sub("hello, 1234", "([0-9])[0-9]", lookup, "jo")
+			ngx.say(newstr)
+        ';
+    }
+--- request
+    GET /re
+--- response_body
+hello, 534
+--- no_error_log
+[error]
+attempt to get length of local 'bit' (a number value)


### PR DESCRIPTION
This commit updates regex.lua to force the use of string types
in situations where the '#' operator is called. This resolves
potential thread abort situations where non-string types are used
as parameters to ngx.re.(g)sub, ngx.re.(g)match and ngx.re.find
as noted in issue #22.