### PR TITLE
Remove request check from {priv_key,cert}_pem_to_der in ssl.lua

### DIFF
--- a/lib/ngx/ssl.lua
+++ b/lib/ngx/ssl.lua
@@ -151,11 +151,6 @@ end
 
 
 function _M.cert_pem_to_der(pem)
-    local r = getfenv(0).__ngx_req
-    if not r then
-        return error("no request found")
-    end
-
     local outbuf = get_string_buf(#pem)
 
     local sz = C.ngx_http_lua_ffi_cert_pem_to_der(pem, #pem, outbuf, errmsg)
@@ -168,11 +163,6 @@ end
 
 
 function _M.priv_key_pem_to_der(pem)
-    local r = getfenv(0).__ngx_req
-    if not r then
-        return error("no request found")
-    end
-
     local outbuf = get_string_buf(#pem)
 
     local sz = C.ngx_http_lua_ffi_priv_key_pem_to_der(pem, #pem, outbuf, errmsg)


### PR DESCRIPTION
Both `cert_pem_to_der` and `priv_key_pem_to_der` check to ensure that `__ngx_req` exists. At no point in either function is the request used (it would appear to be a holdover from other functions). This is problematic because both functions ['can be called in whatever contexts'](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md#cert_pem_to_der) but init_by_lua does not have a request.

This pull request removes the check for `__ngx_req` from both `cert_pem_to_der` and `priv_key_pem_to_der`, and allows both fucntions to be used in init_by_lua.