### PR TITLE
bugfix: will enter endless loop when regex is empty string.

### DIFF
--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -115,20 +115,28 @@ function _M.split(subj, regex, opts, ctx, max, res)
         return error("res is not a table", 2)
     end
 
+    local len = #subj
+    if ctx.pos > len then
+        res[1] = nil
+        return res
+    end
+
     if regex == "" then
         local pos = ctx.pos
-        local len = #subj
+        local last = len
         if max > 0 then
-            len = math_min(len, pos + max)
+            last = math_min(len, pos + max - 1)
         end
 
         local res_idx = 1
-        for i = pos, len do
-            res[res_idx] = sub(subj, i, i)
+        while pos < last do
+            res[res_idx] = sub(subj, pos, pos)
             res_idx = res_idx + 1
+            pos = pos + 1
         end
 
-        res[res_idx] = nil
+        res[res_idx] = sub(subj, pos)
+        res[res_idx + 1] = nil
 
         return res
     end
@@ -204,7 +212,7 @@ function _M.split(subj, regex, opts, ctx, max, res)
 
     -- trailing nil for non-cleared res tables
 
-    res[res_idx + 1] = sub(subj, sub_idx, #subj)
+    res[res_idx + 1] = sub(subj, sub_idx)
     res[res_idx + 2] = nil
 
     return res

--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -115,6 +115,24 @@ function _M.split(subj, regex, opts, ctx, max, res)
         return error("res is not a table", 2)
     end
 
+    if regex == "" then
+        local pos = ctx.pos
+        local len = #subj
+        if max > 0 then
+            len = math_min(len, pos + max)
+        end
+
+        local res_idx = 1
+        for i = pos, len do
+            res[res_idx] = sub(subj, i, i)
+            res_idx = res_idx + 1
+        end
+
+        res[res_idx] = nil
+
+        return res
+    end
+
     -- compile regex
 
     local compiled, compile_once, flags = re_match_compile(regex, opts)

--- a/lib/ngx/re.md
+++ b/lib/ngx/re.md
@@ -78,6 +78,16 @@ local res, err = ngx_re.split("a,b,c,d", "(,)")
 -- res is now {"a", ",", "b", ",", "c", ",", "d"}
 ```
 
+When `regex` is empty string `""`, the `subject` will be split into chars,
+like so:
+
+```lua
+local ngx_re = require "ngx.re"
+
+local res, err = ngx_re.split("abcd", "")
+-- res is now {"a", "b", "c", "d"}
+```
+
 The optional `ctx` table argument can be a Lua table holding an optional `pos`
 field. When the `pos` field in the `ctx` table argument is specified,
 `ngx_re.split` will start splitting the `subject` from that index:

--- a/t/re-split.t
+++ b/t/re-split.t
@@ -708,7 +708,36 @@ attempt to get length of local 'subj' (a number value)
 
 
 
-=== TEST 21: regex is ""
+=== TEST 21: split matches, pos is larger than subject length
+--- http_config eval: $::HttpConfig
+--- config
+    location = /re {
+        content_by_lua_block {
+            local ngx_re = require "ngx.re"
+
+            local res, err = ngx_re.split("a,b,c,d,e", ",", nil, { pos = 10 })
+            if err then
+                ngx.log(ngx.ERR, "failed: ", err)
+                return
+            end
+
+            for i = 1, #res do
+                ngx.say(res[i])
+            end
+            ngx.say("len: ", #res)
+        }
+    }
+--- request
+GET /re
+--- response_body
+len: 0
+--- no_error_log
+[error]
+[TRACE
+
+
+
+=== TEST 22: regex is ""
 --- http_config eval: $::HttpConfig
 --- config
     location /re {
@@ -737,6 +766,102 @@ GET /re
 4
 5
 len: 5
+--- no_error_log
+[error]
+[TRACE
+
+
+
+=== TEST 23: regex is "" with pos
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            local ngx_re = require "ngx.re"
+
+            local res, err = ngx_re.split("12345", "", "jo", { pos = 2 })
+            if err then
+                ngx.log(ngx.ERR, "failed: ", err)
+                return
+            end
+
+            for i = 1, #res do
+                ngx.say(res[i])
+            end
+
+            ngx.say("len: ", #res)
+        }
+    }
+--- request
+GET /re
+--- response_body
+2
+3
+4
+5
+len: 4
+--- no_error_log
+[error]
+[TRACE
+
+
+
+=== TEST 24: regex is "" with pos larger than subject length
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            local ngx_re = require "ngx.re"
+
+            local res, err = ngx_re.split("12345", "", "jo", { pos = 10 })
+            if err then
+                ngx.log(ngx.ERR, "failed: ", err)
+                return
+            end
+
+            for i = 1, #res do
+                ngx.say(res[i])
+            end
+
+            ngx.say("len: ", #res)
+        }
+    }
+--- request
+GET /re
+--- response_body
+len: 0
+--- no_error_log
+[error]
+[TRACE
+
+
+
+=== TEST 25: regex is "" with pos & max
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            local ngx_re = require "ngx.re"
+
+            local res, err = ngx_re.split("12345", "", "jo", { pos = 2 }, 2)
+            if err then
+                ngx.log(ngx.ERR, "failed: ", err)
+                return
+            end
+
+            for i = 1, #res do
+                ngx.say(res[i])
+            end
+
+            ngx.say("len: ", #res)
+        }
+    }
+--- request
+GET /re
+--- response_body
+2
+345
+len: 2
 --- no_error_log
 [error]
 [TRACE

--- a/t/re-split.t
+++ b/t/re-split.t
@@ -705,3 +705,38 @@ qr/\[TRACE   \d+/
 --- no_error_log
 [error]
 attempt to get length of local 'subj' (a number value)
+
+
+
+=== TEST 21: regex is ""
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            local ngx_re = require "ngx.re"
+
+            local res, err = ngx_re.split("12345", "", "jo")
+            if err then
+                ngx.log(ngx.ERR, "failed: ", err)
+                return
+            end
+
+            for i = 1, #res do
+                ngx.say(res[i])
+            end
+
+            ngx.say("len: ", #res)
+        }
+    }
+--- request
+GET /re
+--- response_body
+1
+2
+3
+4
+5
+len: 5
+--- no_error_log
+[error]
+[TRACE


### PR DESCRIPTION
For now, when `regex` is empty string `""`, the `subject` will be split into chars, like so:
```lua
local ngx_re = require "ngx.re"

local res, err = ngx_re.split("abcd", "")
-- res is now {"a", "b", "c", "d"}
```