### PR TITLE
ffi_write new API: Create output.lua

### DIFF
--- a/lib/resty/core/output.lua
+++ b/lib/resty/core/output.lua
@@ -1,10 +1,11 @@
 local ffi = require "ffi"
 local base = require "resty.core.base"
 local FFI_OK = base.FFI_OK
+local FFI_ERROR = base.FFI_ERROR
 local C = ffi.C
 
 local _M = {
-    _VERSION = base.version
+    version = base.version
 }
 
 ffi.cdef[[
@@ -16,9 +17,8 @@ ffi.cdef[[
 
 function _M.ffi_write(lua_string, offset, len)
     local r = getfenv(0).__ngx_req
-
-    if not r then       
-       return false
+    if not r then
+        return false, FFI_ERROR
     end
 
     local rc = C.ngx_http_lua_ffi_write(r,
@@ -26,12 +26,12 @@ function _M.ffi_write(lua_string, offset, len)
                                         offset,
                                         len)
 
-    if rc == FFI_OK then      
-      return true
-    else      
-      return false, rc
+    if rc == FFI_OK then
+        return true
+    else
+        return false, rc
     end
- end
+end
 
 
 return _M

--- a/lib/resty/core/output.lua
+++ b/lib/resty/core/output.lua
@@ -14,7 +14,7 @@ ffi.cdef[[
                 size_t len);
 ]]
 
-function output.ffi_write(lua_string, offset, len)
+function _M.ffi_write(lua_string, offset, len)
     local r = getfenv(0).__ngx_req
 
     if not r then       

--- a/lib/resty/core/output.lua
+++ b/lib/resty/core/output.lua
@@ -18,7 +18,7 @@ function output.ffi_write(lua_string, offset, len)
     local r = getfenv(0).__ngx_req
 
     if not r then       
-       return false, rc
+       return false
     end
 
     local rc = C.ngx_http_lua_ffi_write(r,

--- a/lib/resty/core/output.lua
+++ b/lib/resty/core/output.lua
@@ -16,11 +16,9 @@ local _M = {
 
 
 ffi.cdef[[
-        int ngx_http_lua_ffi_write(ngx_http_request_t *r,
-                const char* str,
-                size_t offset,
-                size_t len,
-                char **err);
+    int ngx_http_lua_ffi_write(ngx_http_request_t *r,
+                               const char* str, size_t offset,
+                               size_t len, char **err);
 ]]
 
 
@@ -30,17 +28,14 @@ function _M.ffi_write(lua_string, offset, len)
         return error("no request found")
     end
 
-    local rc = C.ngx_http_lua_ffi_write(r,
-                                        lua_string,
-                                        offset,
-                                        len,
-                                        errmsg)
+    local rc = C.ngx_http_lua_ffi_write(r, lua_string, offset,
+                                        len, errmsg)
 
     if rc == FFI_OK then
         return true
-    else
-        return false, ffi_str(errmsg[0])
     end
+
+    return false, ffi_str(errmsg[0])
 end
 
 

--- a/lib/resty/core/output.lua
+++ b/lib/resty/core/output.lua
@@ -1,13 +1,11 @@
 local ffi = require "ffi"
 local base = require "resty.core.base"
 local FFI_OK = base.FFI_OK
-local ffi_cast = ffi.cast
-local const_char_ptr = ffi.typeof("const char *")
 local C = ffi.C
---local get_string_buf = base.get_string_buf
---local get_size_ptr = base.get_size_ptr
 
-local output = {}
+local _M = {
+    _VERSION = base.version
+}
 
 ffi.cdef[[
         int ngx_http_lua_ffi_write(ngx_http_request_t *r,
@@ -17,34 +15,23 @@ ffi.cdef[[
 ]]
 
 function output.ffi_write(lua_string, offset, len)
-    --local ERR_BUF_SIZE = 128
-    --local err = get_string_buf(ERR_BUF_SIZE)
-    --local errlen = get_size_ptr()
-    local buff = ffi_cast(const_char_ptr, lua_string)
-
     local r = getfenv(0).__ngx_req
 
-    if not r then
-       --return false, error("no request found")
-       ngx.log(ngx.ERR, "no request found")
-       return false
+    if not r then       
+       return false, rc
     end
 
     local rc = C.ngx_http_lua_ffi_write(r,
-                           buff,
-                           offset,
-                           len)
+                                        lua_string,
+                                        offset,
+                                        len)
 
-    if rc == FFI_OK then
-      ngx.log(ngx.INFO, "ffi_write success: code = "..rc)
+    if rc == FFI_OK then      
       return true
-    else
-      --errlen[0] = ERR_BUF_SIZE
-      --return false, error(ffi_string(err, errlen[0]))
-      ngx.log(ngx.INFO, "ffi_write error: code = "..rc)
-      return false
+    else      
+      return false, rc
     end
-
  end
 
-return output
+
+return _M

--- a/lib/resty/core/output.lua
+++ b/lib/resty/core/output.lua
@@ -1,35 +1,45 @@
 local ffi = require "ffi"
 local base = require "resty.core.base"
+
+
+local ffi_str = ffi.string
+local errmsg = base.get_errmsg_ptr()
 local FFI_OK = base.FFI_OK
-local FFI_ERROR = base.FFI_ERROR
 local C = ffi.C
+local getfenv = getfenv
+local error = error
+
 
 local _M = {
     version = base.version
 }
 
+
 ffi.cdef[[
         int ngx_http_lua_ffi_write(ngx_http_request_t *r,
                 const char* str,
                 size_t offset,
-                size_t len);
+                size_t len,
+                char **err);
 ]]
+
 
 function _M.ffi_write(lua_string, offset, len)
     local r = getfenv(0).__ngx_req
     if not r then
-        return false, FFI_ERROR
+        return error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_write(r,
                                         lua_string,
                                         offset,
-                                        len)
+                                        len,
+                                        errmsg)
 
     if rc == FFI_OK then
         return true
     else
-        return false, rc
+        return false, ffi_str(errmsg[0])
     end
 end
 

--- a/lib/resty/core/output.lua
+++ b/lib/resty/core/output.lua
@@ -1,0 +1,50 @@
+local ffi = require "ffi"
+local base = require "resty.core.base"
+local FFI_OK = base.FFI_OK
+local ffi_cast = ffi.cast
+local const_char_ptr = ffi.typeof("const char *")
+local C = ffi.C
+--local get_string_buf = base.get_string_buf
+--local get_size_ptr = base.get_size_ptr
+
+local output = {}
+
+ffi.cdef[[
+        int ngx_http_lua_ffi_write(ngx_http_request_t *r,
+                const char* str,
+                size_t offset,
+                size_t len);
+]]
+
+function output.ffi_write(lua_string, offset, len)
+    --local ERR_BUF_SIZE = 128
+    --local err = get_string_buf(ERR_BUF_SIZE)
+    --local errlen = get_size_ptr()
+    local buff = ffi_cast(const_char_ptr, lua_string)
+
+    local r = getfenv(0).__ngx_req
+
+    if not r then
+       --return false, error("no request found")
+       ngx.log(ngx.ERR, "no request found")
+       return false
+    end
+
+    local rc = C.ngx_http_lua_ffi_write(r,
+                           buff,
+                           offset,
+                           len)
+
+    if rc == FFI_OK then
+      ngx.log(ngx.INFO, "ffi_write success: code = "..rc)
+      return true
+    else
+      --errlen[0] = ERR_BUF_SIZE
+      --return false, error(ffi_string(err, errlen[0]))
+      ngx.log(ngx.INFO, "ffi_write error: code = "..rc)
+      return false
+    end
+
+ end
+
+return output


### PR DESCRIPTION
ffi_write new API function.

Requires PR: https://github.com/openresty/lua-nginx-module/pull/960

This new FFI API function is used to print a string buffer on the client output starting from a given offset and ending at given length. This avoids the overhead of creating another string in the lua land.