### PR TITLE
chore: added 'coroutine._yield' to read-only globals

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,2 +1,5 @@
 std = 'ngx_lua'
 unused_args = false
+read_globals = {
+    "coroutine._yield"
+}


### PR DESCRIPTION
This fixes builds with Luacheck 0.19.0+