### PR TITLE
feat: added ngx.math module for safe PRNG seeding

### DIFF
--- a/lib/ngx/math.lua
+++ b/lib/ngx/math.lua
@@ -1,0 +1,46 @@
+local ffi = require "ffi"
+local base = require "resty.core.base"
+
+
+local C = ffi.C
+local ngx = ngx
+local error = error
+local tonumber = tonumber
+local math_randomseed = math.randomseed
+
+
+ffi.cdef [[
+    long random(void);
+]]
+
+
+local function random()
+    return tonumber(C.random())
+end
+
+
+local function fnop() end
+
+
+local _M = { version = base.version }
+
+
+function _M.randomseed(nop)
+    if ngx.get_phase() == "init" then
+        return error("API disabled in the current context")
+    end
+
+    local r = random()
+
+    math_randomseed(r)
+
+    if nop then
+        -- luacheck: globals = math.randomseed
+        math.randomseed = fnop
+    end
+
+    return r
+end
+
+
+return _M

--- a/t/math.t
+++ b/t/math.t
@@ -1,0 +1,222 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+master_on();
+workers(5);
+
+repeat_each(3);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+our $pwd = cwd();
+
+our $HttpConfig = <<_EOC_;
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+    init_by_lua_block {
+        local verbose = false
+        if verbose then
+            local dump = require "jit.dump"
+            dump.on("b", "$Test::Nginx::Util::ErrLogFile")
+        else
+            local v = require "jit.v"
+            v.on("$Test::Nginx::Util::ErrLogFile")
+        end
+
+        require "resty.core"
+        -- jit.off()
+    }
+_EOC_
+
+check_accum_error_log();
+run_tests();
+
+__DATA__
+
+=== TEST 1: math.random defaults to identical seeds
+--- http_config eval
+qq{
+    lua_shared_dict randoms 1m;
+
+    init_worker_by_lua_block {
+        local dict = ngx.shared.randoms
+        local u = math.random()
+        assert(dict:add(u, true))
+    }
+}
+--- config
+    location = /t {
+        return 200;
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log eval
+qr/\[error\] .*? init_worker_by_lua:\d+: exists/
+
+
+
+=== TEST 2: ngx.math.randomseed uses truly unique seeds
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    lua_shared_dict randoms 1m;
+
+    init_worker_by_lua_block {
+        local ngx_math = require "ngx.math"
+
+        ngx_math.randomseed()
+
+        local dict = ngx.shared.randoms
+        local u = math.random()
+        assert(dict:add(u, true))
+    }
+}
+--- config
+    location = /t {
+        return 200;
+    }
+--- request
+GET /t
+--- response_body
+
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: ngx.math.randomseed returns used seed
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_math = require "ngx.math"
+
+            ngx.say(ngx_math.randomseed())
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+\d+
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: ngx.math.randomseed disabled in init context
+--- http_config eval
+qq{
+    lua_package_path "$::pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+
+    init_by_lua_block {
+        local ngx_math = require "ngx.math"
+
+        local ok, err = pcall(ngx_math.randomseed)
+        if not ok then
+            ngx.log(ngx.NOTICE, err)
+        end
+    }
+}
+--- config
+    location = /t {
+        return 200;
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log eval
+qr/\[notice\] .*? init_by_lua:\d+: API disabled in the current context/
+
+
+
+=== TEST 5: ngx.math.randomseed does not nop math.randomseed (dangerous)
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    lua_shared_dict randoms 1m;
+
+    init_worker_by_lua_block {
+        local ngx_math = require "ngx.math"
+
+        ngx_math.randomseed()
+
+        math.randomseed(os.time())
+
+        local dict = ngx.shared.randoms
+        local u = math.random()
+        assert(dict:add(u, true))
+    }
+}
+--- config
+    location = /t {
+        return 200;
+    }
+--- request
+GET /t
+--- response_body
+
+--- error_log eval
+qr/\[error\] .*? init_worker_by_lua:\d+: exists/
+
+
+
+=== TEST 6: ngx.math.randomseed can nop math.randomseed
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    lua_shared_dict randoms 1m;
+
+    init_worker_by_lua_block {
+        local ngx_math = require "ngx.math"
+
+        ngx_math.randomseed(true)
+
+        math.randomseed(os.time())
+
+        local dict = ngx.shared.randoms
+        local u = math.random()
+        assert(dict:add(u, true))
+    }
+}
+--- config
+    location = /t {
+        return 200;
+    }
+--- request
+GET /t
+--- response_body
+
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: ngx.math.randomseed JITs
+--- SKIP: ngx.get_phase NYI, see lua-resty-core#78
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_math = require "ngx.math"
+
+            for i = 1, 100 do
+                ngx_math.randomseed()
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+
+--- no_error_log
+[error]
+ -- NYI:
+--- error_log eval
+qr/\[TRACE\s+\d+\s+content_by_lua\(nginx\.conf:\d+\):2 loop\]/


### PR DESCRIPTION
This addresses one of the biggest pitas of ngx_lua: seeding the PRNG with a good entropy seed. Seeding with a low entropy is a *user error* that can lead to **huge** issues.

Ex: producing identical UUIDs with libraries such as [lua-resty-jit-uuid](https://github.com/thibaultcha/lua-resty-jit-uuid).

There are 2 main issues with seeding the PRNG in ngx_lua:

1. We often see such seeding out there in lua-resty libraries or user code:
- `math.randomseed(os.time())` - traditional PUC-Lua seeding -> will lead to all workers having the same seed.
- `math.randomseed(ngx.time() * 1000)` -> will probably lead all workers to having the same seed.
- `math.randomseed(ngx.worker.pid())` -> safer, used by [lua-resty-jit-uuid](https://github.com/thibaultcha/lua-resty-jit-uuid), but can still lead to duplicate seeds if spawning multiple Nginx nodes via containers (where the workers pids are identical)
- Using a seed coming from OpenSSL's `RAND_bytes`, an approach we have taken with Kong.

2. Regardless of all the above methods, if the seed is later overridden by a third-party lua-resty library, all efforts are lost and the PRNG's entropy nullified is again.

To address those concerns, I propose `ngx.math`. Here is a (very) quick draft of the documentation for this module:


---


**usage**: `seed = ngx_math.randomseed(nop?)`
**contexts**: [all but `init`]

Will seed the Lua PRNG via libc's `random()`. This is safer than using a low-entropy seed such as `os.time()` or others, since each Nginx worker's PRNG is already seeded via a combination of `pid + sec + msec`.

The produced seed is returned to the caller to provide  introspection capabilities in case you suspect multiple workers to be using the same seed.

The optional `nop` argument is a boolean that will NOP the `math.randomseed()` function. Doing so will safeguard your PRNG against third-party code doing low-entropy seeding later in your application's lifetime.

You should call this function in the `init_worker_by_lua` context.


---


I believe this will raise awareness for this pita, and encourage users to be safer out there with their PRNG seeding.