### PR TITLE
Should return nil if subj is nil in split function

### DIFF
--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -84,6 +84,9 @@ end
 
 
 function _M.split(subj, regex, opts, ctx, max, res)
+    if subj == nil then
+        return nil, nil
+    end
     -- we need to cast this to strings to avoid exceptions when they are
     -- something else.
     -- needed because of further calls to string.sub in this function.


### PR DESCRIPTION
If subj is nil, the split function will return nil and no error. However the nil is a string "nil", as tostring works. I think it makes sense to return nil type if subj is nil