### PR TITLE
feature: Added ocsp.get_ocsp_nextupdate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/nginx-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b ocsp-nextupdate https://github.com/alubbe/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/lib/ngx/ocsp.lua
+++ b/lib/ngx/ocsp.lua
@@ -32,6 +32,7 @@ int ngx_http_lua_ffi_ssl_validate_ocsp_response(const unsigned char *resp,
     size_t resp_len, const char *chain_data, size_t chain_len,
     unsigned char *errbuf, size_t *errbuf_size);
 
+typedef long time_t;
 int ngx_http_lua_ffi_ssl_ocsp_get_nextupdate(const unsigned char *resp,
     size_t resp_len, const char *chain_data, size_t chain_len,
     time_t* nextupdate, unsigned char *errbuf, size_t *errbuf_size);

--- a/lib/ngx/ocsp.lua
+++ b/lib/ngx/ocsp.lua
@@ -33,6 +33,7 @@ int ngx_http_lua_ffi_ssl_validate_ocsp_response(const unsigned char *resp,
     unsigned char *errbuf, size_t *errbuf_size);
 
 typedef long time_t;
+
 int ngx_http_lua_ffi_ssl_ocsp_get_nextupdate(const unsigned char *resp,
     size_t resp_len, const char *chain_data, size_t chain_len,
     time_t* nextupdate, unsigned char *errbuf, size_t *errbuf_size);

--- a/lib/ngx/ocsp.lua
+++ b/lib/ngx/ocsp.lua
@@ -129,7 +129,7 @@ function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
 end
 
 
-function _M.get_ocsp_nextupdate(resp, chain, max_errmsg_len)
+function _M.get_ocsp_next_update(resp, chain, max_errmsg_len)
 
     local errbuf_size = max_errmsg_len
     if not errbuf_size then

--- a/lib/ngx/ocsp.md
+++ b/lib/ngx/ocsp.md
@@ -211,9 +211,9 @@ being 4KB).
 
 [Back to TOC](#table-of-contents)
 
-get_ocsp_nextupdate
+get_ocsp_next_update
 ----------------------
-**syntax:** *ok, err = ocsp.get_ocsp_nextupdate(ocsp_resp, der_cert_chain, max_err_msg_len)*
+**syntax:** *next_update, err = ocsp.get_ocsp_next_update(ocsp_resp, der_cert_chain, max_err_msg_len)*
 
 **context:** *any*
 

--- a/lib/ngx/ocsp.md
+++ b/lib/ngx/ocsp.md
@@ -204,8 +204,27 @@ server certificate chain in DER format as specified in the `der_cert_chain` argu
 
 Returns true when the validation is successful.
 
-In case of failures, returns `nil` and a string
-describing the failure. The maximum
+In case of failures, returns `nil` and a string describing the failure. The maximum
+length of the error string is controlled by the optional `max_err_msg` argument (which defaults
+to the default internal string buffer size used throughout this `lua-resty-core` library, usually
+being 4KB).
+
+[Back to TOC](#table-of-contents)
+
+get_ocsp_nextupdate
+----------------------
+**syntax:** *ok, err = ocsp.get_ocsp_nextupdate(ocsp_resp, der_cert_chain, max_err_msg_len)*
+
+**context:** *any*
+
+Extracts the nextUpdate timestamp from the raw OCSP response data specified by the `ocsp_resp`
+argument using the SSL server certificate chain in DER format as specified in the `der_cert_chain`
+argument.
+
+Returns the timestamp value of nextUpdate in seconds. This value can be passed into `os.date()`
+for formatting or compared with `os.time()` to determine when it should be updated next.
+
+In case of failures, returns `nil` and a string describing the failure. The maximum
 length of the error string is controlled by the optional `max_err_msg` argument (which defaults
 to the default internal string buffer size used throughout this `lua-resty-core` library, usually
 being 4KB).

--- a/t/ocsp.t
+++ b/t/ocsp.t
@@ -1575,8 +1575,8 @@ ocsp status resp set ok: no status req,
             local resp = f:read("*a")
             f:close()
 
-            local nextupdate, err = ocsp.get_ocsp_nextupdate(resp, cert_data)
-            if not nextupdate then
+            local next_update, err = ocsp.get_ocsp_next_update(resp, cert_data)
+            if not next_update then
                 ngx.log(ngx.ERR, "failed to get OCSP nextUpdate: ", err)
                 return
             end

--- a/t/ocsp.t
+++ b/t/ocsp.t
@@ -9,7 +9,7 @@ use Cwd qw(cwd);
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6 + 13);
+plan tests => repeat_each() * (blocks() * 6 + 14);
 
 our $CWD = cwd();
 

--- a/t/ocsp.t
+++ b/t/ocsp.t
@@ -1577,7 +1577,7 @@ ocsp status resp set ok: no status req,
 
             local next_update, err = ocsp.get_ocsp_next_update(resp, cert_data)
             if not next_update then
-                ngx.log(ngx.ERR, "failed to get OCSP nextUpdate: ", err)
+                ngx.log(ngx.WARN, "failed to get OCSP nextUpdate: ", err)
                 return
             end
 


### PR DESCRIPTION
This PR is a possible solution to https://github.com/openresty/lua-resty-core/issues/75 and is complemented by https://github.com/openresty/lua-nginx-module/pull/1041.

It is missing more tests, mainly because none of the existing mock ocsp responses contain the nextUpdate field. I will need help on how to add those. I can confirm that this works as intended on the OCSP responses sent by Let's Encrypt.

Looking forward to your feedback.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
