### PR TITLE
feature: implemented the ngx.errlog.get_sys_filter_level()  API function to get system default log level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b errlog_log_level https://github.com/spacewander/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/lib/ngx/errlog.lua
+++ b/lib/ngx/errlog.lua
@@ -21,6 +21,8 @@ int ngx_http_lua_ffi_errlog_set_filter_level(int level, unsigned char *err,
     size_t *errlen);
 int ngx_http_lua_ffi_errlog_get_msg(char **log, int *loglevel,
     unsigned char *err, size_t *errlen);
+
+int ngx_http_lua_ffi_errlog_log_level(ngx_http_request_t *r);
 ]]
 
 
@@ -84,6 +86,12 @@ function _M.get_logs(max, logs)
     end
 
     return logs
+end
+
+
+function _M.log_level()
+    local r = getfenv(0).__ngx_req
+    return C.ngx_http_lua_ffi_errlog_log_level(r)
 end
 
 

--- a/lib/ngx/errlog.lua
+++ b/lib/ngx/errlog.lua
@@ -22,7 +22,7 @@ int ngx_http_lua_ffi_errlog_set_filter_level(int level, unsigned char *err,
 int ngx_http_lua_ffi_errlog_get_msg(char **log, int *loglevel,
     unsigned char *err, size_t *errlen);
 
-int ngx_http_lua_ffi_errlog_log_level(ngx_http_request_t *r);
+int ngx_http_lua_ffi_errlog_get_sys_filtering_level(ngx_http_request_t *r);
 ]]
 
 
@@ -89,9 +89,9 @@ function _M.get_logs(max, logs)
 end
 
 
-function _M.log_level()
+function _M.get_sys_filtering_level()
     local r = getfenv(0).__ngx_req
-    return C.ngx_http_lua_ffi_errlog_log_level(r)
+    return C.ngx_http_lua_ffi_errlog_get_sys_filtering_level(r)
 end
 
 

--- a/lib/ngx/errlog.lua
+++ b/lib/ngx/errlog.lua
@@ -91,7 +91,7 @@ end
 
 function _M.get_sys_filtering_level()
     local r = getfenv(0).__ngx_req
-    return C.ngx_http_lua_ffi_errlog_get_sys_filtering_level(r)
+    return tonumber(C.ngx_http_lua_ffi_errlog_get_sys_filtering_level(r))
 end
 
 

--- a/lib/ngx/errlog.lua
+++ b/lib/ngx/errlog.lua
@@ -22,7 +22,7 @@ int ngx_http_lua_ffi_errlog_set_filter_level(int level, unsigned char *err,
 int ngx_http_lua_ffi_errlog_get_msg(char **log, int *loglevel,
     unsigned char *err, size_t *errlen);
 
-int ngx_http_lua_ffi_errlog_get_sys_filtering_level(ngx_http_request_t *r);
+int ngx_http_lua_ffi_errlog_get_sys_filter_level(ngx_http_request_t *r);
 ]]
 
 
@@ -89,9 +89,9 @@ function _M.get_logs(max, logs)
 end
 
 
-function _M.get_sys_filtering_level()
+function _M.get_sys_filter_level()
     local r = getfenv(0).__ngx_req
-    return tonumber(C.ngx_http_lua_ffi_errlog_get_sys_filtering_level(r))
+    return tonumber(C.ngx_http_lua_ffi_errlog_get_sys_filter_level(r))
 end
 
 

--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -221,16 +221,14 @@ Return system default filtering level as an integer. Later the return value
 could be used as Nginx log level constant. For example:
 
 ```lua
-init_by_lua_block {
-    local errlog = require "ngx.errlog"
-    local log_level = error_log.get_sys_filtering_level()
-    -- Now the filter level is always one level lower than system default log level
-    local status, err = errlog.set_filter_level(log_level - 1)
-    if not status then
-        ngx.log(ngx.ERR, err)
-        return
-    end
-}
+local errlog = require "ngx.errlog"
+local log_level = error_log.get_sys_filtering_level()
+-- Now the filter level is always a level higher than system default log level on priority
+local status, err = errlog.set_filter_level(log_level - 1)
+if not status then
+    ngx.log(ngx.ERR, err)
+    return
+end
 ```
 
 [Back to TOC](#table-of-contents)

--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -222,7 +222,7 @@ value could be used as an Nginx log level constant. For example:
 
 ```lua
 local errlog = require "ngx.errlog"
-local log_level = error_log.get_sys_filter_level()
+local log_level = errlog.get_sys_filter_level()
 -- Now the filter level is always one level higher than system default log level on priority
 local status, err = errlog.set_filter_level(log_level - 1)
 if not status then

--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -13,7 +13,7 @@ Table of Contents
 * [Methods](#methods)
     * [set_filter_level](#set_filter_level)
     * [get_logs](#get_logs)
-    * [get_sys_filtering_level](#get_sys_filtering_level)
+    * [get_sys_filter_level](#get_sys_filter_level)
 * [Community](#community)
     * [English Mailing List](#english-mailing-list)
     * [Chinese Mailing List](#chinese-mailing-list)
@@ -211,18 +211,18 @@ clear the table yourself before feeding it into the `errlog.get_logs` function.
 
 [Back to TOC](#table-of-contents)
 
-get_sys_filtering_level
------------------------
-**syntax:** *log_level = log_module.get_sys_filtering_level()*
+get_sys_filter_level
+--------------------
+**syntax:** *log_level = log_module.get_sys_filter_level()*
 
 **context:** *any*
 
-Return the system's default filtering level as an integer. Later, the returned
+Return the system's default filter level as an integer. Later, the returned
 value could be used as an Nginx log level constant. For example:
 
 ```lua
 local errlog = require "ngx.errlog"
-local log_level = error_log.get_sys_filtering_level()
+local log_level = error_log.get_sys_filter_level()
 -- Now the filter level is always one level higher than system default log level on priority
 local status, err = errlog.set_filter_level(log_level - 1)
 if not status then

--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -221,16 +221,16 @@ Return system default filtering level as an integer. Later the return value
 could be used as Nginx log level constant. For example:
 
 ```lua
--- config.lua
-local errlog = require "ngx.errlog"
-_M.log_level = error_log.get_sys_filtering_level()
-return _M
-```
-
-```lua
--- req.lua
-local log_level = config.log_level
-errlog.set_filter_level(log_level)
+init_by_lua_block {
+    local errlog = require "ngx.errlog"
+    local log_level = error_log.get_sys_filtering_level()
+    -- Now the filter level is always one level lower than system default log level
+    local status, err = errlog.set_filter_level(log_level - 1)
+    if not status then
+        ngx.log(ngx.ERR, err)
+        return
+    end
+}
 ```
 
 [Back to TOC](#table-of-contents)

--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -217,13 +217,13 @@ get_sys_filtering_level
 
 **context:** *any*
 
-Return system default filtering level as an integer. Later the return value
-could be used as Nginx log level constant. For example:
+Return the system's default filtering level as an integer. Later, the returned
+value could be used as an Nginx log level constant. For example:
 
 ```lua
 local errlog = require "ngx.errlog"
 local log_level = error_log.get_sys_filtering_level()
--- Now the filter level is always a level higher than system default log level on priority
+-- Now the filter level is always one level higher than system default log level on priority
 local status, err = errlog.set_filter_level(log_level - 1)
 if not status then
     ngx.log(ngx.ERR, err)

--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -13,7 +13,7 @@ Table of Contents
 * [Methods](#methods)
     * [set_filter_level](#set_filter_level)
     * [get_logs](#get_logs)
-    * [log_level](#log_level)
+    * [get_sys_filtering_level](#get_sys_filtering_level)
 * [Community](#community)
     * [English Mailing List](#english-mailing-list)
     * [Chinese Mailing List](#chinese-mailing-list)
@@ -211,29 +211,26 @@ clear the table yourself before feeding it into the `errlog.get_logs` function.
 
 [Back to TOC](#table-of-contents)
 
-log_level
---------
-**syntax:** *log_level = log_module.log_level()*
+get_sys_filtering_level
+-----------------------
+**syntax:** *log_level = log_module.get_sys_filtering_level()*
 
 **context:** *any*
 
-Return configured error log level as an integer. Later the return value could be
-interacted with other Nginx log level constants. For example:
+Return system default filtering level as an integer. Later the return value
+could be used as Nginx log level constant. For example:
 
 ```lua
 -- config.lua
 local errlog = require "ngx.errlog"
-_M.log_level = error_log.log_level()
+_M.log_level = error_log.get_sys_filtering_level()
 return _M
 ```
 
 ```lua
 -- req.lua
 local log_level = config.log_level
-if log_level >= ngx.WARN then
-    -- Now we save an `encode` operation if we configure error_log level to `error`.
-    ngx.log(ngx.WARN, cjson.encode(obj), ...)
-end
+errlog.set_filter_level(log_level)
 ```
 
 [Back to TOC](#table-of-contents)

--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -13,6 +13,7 @@ Table of Contents
 * [Methods](#methods)
     * [set_filter_level](#set_filter_level)
     * [get_logs](#get_logs)
+    * [log_level](#log_level)
 * [Community](#community)
     * [English Mailing List](#english-mailing-list)
     * [Chinese Mailing List](#chinese-mailing-list)
@@ -207,6 +208,33 @@ after the last table element.
 
 When the trailing `nil` is not enough for your purpose, you should
 clear the table yourself before feeding it into the `errlog.get_logs` function.
+
+[Back to TOC](#table-of-contents)
+
+log_level
+--------
+**syntax:** *log_level = log_module.log_level()*
+
+**context:** *any*
+
+Return configured error log level as an integer. Later the return value could be
+interacted with other Nginx log level constants. For example:
+
+```lua
+-- config.lua
+local errlog = require "ngx.errlog"
+_M.log_level = error_log.log_level()
+return _M
+```
+
+```lua
+-- req.lua
+local log_level = config.log_level
+if log_level >= ngx.WARN then
+    -- Now we save an `encode` operation if we configure error_log level to `error`.
+    ngx.log(ngx.WARN, cjson.encode(obj), ...)
+end
+```
 
 [Back to TOC](#table-of-contents)
 

--- a/t/errlog.t
+++ b/t/errlog.t
@@ -935,43 +935,45 @@ end
 
 
 
-=== TEST 23: the error log level is "debug"
+=== TEST 23: the system default filtering level is "debug"
 --- config
     location /t {
         content_by_lua_block {
             local errlog = require "ngx.errlog"
-            ngx.print('Is "debug" the current error log level? ', errlog.log_level() == ngx.DEBUG)
+            ngx.print('Is "debug" the system default filtering level? ',
+                      errlog.get_sys_filtering_level() == ngx.DEBUG)
         }
     }
 --- log_level: debug
 --- request
 GET /t
 --- response_body chomp
-Is "debug" the current error log level? true
+Is "debug" the system default filtering level? true
 
 
 
-=== TEST 24: the error log level is "emerg"
+=== TEST 24: the system default filtering level is "emerg"
 --- config
     location /t {
         content_by_lua_block {
             local errlog = require "ngx.errlog"
-            ngx.print('Is "emerg" the current error log level? ', errlog.log_level() == ngx.EMERG)
+            ngx.print('Is "emerg" the system default filtering level? ',
+                      errlog.get_sys_filtering_level() == ngx.EMERG)
         }
     }
 --- log_level: emerg
 --- request
 GET /t
 --- response_body chomp
-Is "emerg" the current error log level? true
+Is "emerg" the system default filtering level? true
 
 
 
-=== TEST 25: get error log level during Nginx worker starts
+=== TEST 25: get system default filtering level during Nginx worker starts
 --- http_config
     init_worker_by_lua_block {
         local errlog = require "ngx.errlog"
-        package.loaded.log_level = errlog.log_level()
+        package.loaded.log_level = errlog.get_sys_filtering_level()
     }
 --- config
     location /t {

--- a/t/errlog.t
+++ b/t/errlog.t
@@ -982,8 +982,7 @@ Is "emerg" the system default filter level? true
 
             if log_level >= ngx.WARN then
                 ngx.log(ngx.WARN, "log a warning event")
-            end
-            if log_level < ngx.WARN then
+            else
                 ngx.log(ngx.WARN, "do not log another warning event")
             end
         }

--- a/t/errlog.t
+++ b/t/errlog.t
@@ -983,8 +983,8 @@ Is "emerg" the system default filtering level? true
             if log_level >= ngx.WARN then
                 ngx.log(ngx.WARN, "log a warning event")
             end
-            if log_level >= ngx.NOTICE then
-                ngx.log(ngx.NOTICE, "log a notice event")
+            if log_level < ngx.WARN then
+                ngx.log(ngx.WARN, "do not log another warning event")
             end
         }
     }
@@ -994,4 +994,4 @@ GET /t
 --- error_log
 log a warning event
 --- no_error_log
-log a notice event
+do not log another warning event

--- a/t/errlog.t
+++ b/t/errlog.t
@@ -16,24 +16,16 @@ my $pwd = cwd();
 add_block_preprocessor(sub {
     my $block = shift;
 
-    my $test_name = $block->name();
     my $http_config = $block->http_config || '';
+    my $init_by_lua_block = $block->init_by_lua_block || 'require "resty.core"';
 
-    if (index($test_name, "TEST 25: ") != -1) {
-        my $lua_package_path = <<_EOC_;
-        lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
-_EOC_
-        $http_config = $lua_package_path . $http_config;
-    }
-    else {
-        $http_config .= <<_EOC_;
+    $http_config .= <<_EOC_;
 
-        lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
-        init_by_lua_block {
-            require "resty.core"
-        }
-_EOC_
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+    init_by_lua_block {
+        $init_by_lua_block
     }
+_EOC_
 
     $block->set_value("http_config", $http_config);
 });
@@ -981,12 +973,11 @@ Is "emerg" the system default filter level? true
 
 
 === TEST 25: get system default filter level during Nginx starts
---- http_config
-    init_by_lua_block {
-        require "resty.core"
-        local errlog = require "ngx.errlog"
-        package.loaded.log_level = errlog.get_sys_filter_level()
-    }
+--- init_by_lua_block
+    require "resty.core"
+    local errlog = require "ngx.errlog"
+    package.loaded.log_level = errlog.get_sys_filter_level()
+
 --- config
     location /t {
         content_by_lua_block {

--- a/t/errlog.t
+++ b/t/errlog.t
@@ -935,45 +935,45 @@ end
 
 
 
-=== TEST 23: the system default filtering level is "debug"
+=== TEST 23: the system default filter level is "debug"
 --- config
     location /t {
         content_by_lua_block {
             local errlog = require "ngx.errlog"
-            ngx.print('Is "debug" the system default filtering level? ',
-                      errlog.get_sys_filtering_level() == ngx.DEBUG)
+            ngx.print('Is "debug" the system default filter level? ',
+                      errlog.get_sys_filter_level() == ngx.DEBUG)
         }
     }
 --- log_level: debug
 --- request
 GET /t
 --- response_body chomp
-Is "debug" the system default filtering level? true
+Is "debug" the system default filter level? true
 
 
 
-=== TEST 24: the system default filtering level is "emerg"
+=== TEST 24: the system default filter level is "emerg"
 --- config
     location /t {
         content_by_lua_block {
             local errlog = require "ngx.errlog"
-            ngx.print('Is "emerg" the system default filtering level? ',
-                      errlog.get_sys_filtering_level() == ngx.EMERG)
+            ngx.print('Is "emerg" the system default filter level? ',
+                      errlog.get_sys_filter_level() == ngx.EMERG)
         }
     }
 --- log_level: emerg
 --- request
 GET /t
 --- response_body chomp
-Is "emerg" the system default filtering level? true
+Is "emerg" the system default filter level? true
 
 
 
-=== TEST 25: get system default filtering level during Nginx worker starts
+=== TEST 25: get system default filter level during Nginx worker starts
 --- http_config
     init_worker_by_lua_block {
         local errlog = require "ngx.errlog"
-        package.loaded.log_level = errlog.get_sys_filtering_level()
+        package.loaded.log_level = errlog.get_sys_filter_level()
     }
 --- config
     location /t {


### PR DESCRIPTION
This pr is subsequent to #116 and depended on https://github.com/openresty/lua-nginx-module/pull/1079.

I'm glad to hear any further feedback.

I hereby granted the copyright of the changes in this pull request
to the authors of this project.