### PR TITLE
style: fixed some typos detected by misspell

### DIFF
--- a/lib/ngx/ocsp.md
+++ b/lib/ngx/ocsp.md
@@ -72,7 +72,7 @@ server {
         -- use cosocket-based HTTP client libraries like lua-resty-http-simple
         -- to send the request (url + ocsp_req as POST params or URL args) to
         -- CA's OCSP server. assuming the server returns the OCSP response
-        -- in the Lua varaible, resp.
+        -- in the Lua variable, resp.
 
         local schema, host, port, ocsp_uri, err = parse_url(ocsp_url)
 

--- a/t/encode-base64.t
+++ b/t/encode-base64.t
@@ -204,7 +204,7 @@ qr/\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):3 loop\]/
 
 
 
-=== TEST 8: set base64 (number) with padding (explictly specified)
+=== TEST 8: set base64 (number) with padding (explicitly specified)
 --- http_config eval: $::HttpConfig
 --- config
     location = /base64 {

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -83,7 +83,7 @@ __DATA__
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -194,7 +194,7 @@ sslv3 alert handshake failure
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -293,7 +293,7 @@ lua ssl server name: "test.com"
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -393,7 +393,7 @@ read SNI name from Lua: test.com
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -509,7 +509,7 @@ read SNI name from Lua: nil, type: nil
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -629,7 +629,7 @@ qr/Using unix socket file .*?nginx\.sock/
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -747,7 +747,7 @@ Using IPv4 address: 127.0.0.1
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -869,7 +869,7 @@ Using IPv6 address: 0.0.0.1
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -996,7 +996,7 @@ lua ssl server name: "test.com"
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1521,7 +1521,7 @@ ssl cert by lua done
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1654,7 +1654,7 @@ lua ssl server name: "test.com"
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1787,7 +1787,7 @@ lua ssl server name: "test.com"
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -1911,7 +1911,7 @@ qr/\[error\] .*? failed to parse pem cert: PEM_read_bio_X509_AUX\(\) failed/
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 
@@ -2035,7 +2035,7 @@ qr/\[error\] .*? failed to parse pem cert: PEM_read_bio_X509\(\) failed/
                 while true do
                     local line, err = sock:receive()
                     if not line then
-                        -- ngx.say("failed to recieve response status line: ", err)
+                        -- ngx.say("failed to receive response status line: ", err)
                         break
                     end
 


### PR DESCRIPTION
[misspell](https://github.com/client9/misspell) is a cmdline tool which could detect commonly misspelled English words.
I think it is the modern solution to catch out typos.

I hereby granted the copyright of the changes in this pull request
to the authors of this project.