### PR TITLE
bugfix: convert regex to string before get its length

### DIFF
--- a/lib/resty/core/regex.lua
+++ b/lib/resty/core/regex.lua
@@ -342,6 +342,7 @@ local function re_match_compile(regex, opts)
         -- print("compiled regex not found, compiling regex...")
         local errbuf = get_string_buf(MAX_ERR_MSG_LEN)
 
+        regex = tostring(regex)
         compiled = C.ngx_http_lua_ffi_compile_regex(regex, #regex,
                                                     flags, pcre_opts,
                                                     errbuf, MAX_ERR_MSG_LEN)
@@ -550,6 +551,7 @@ local function re_sub_compile(regex, opts, replace, func)
         -- print("compiled regex not found, compiling regex...")
         local errbuf = get_string_buf(MAX_ERR_MSG_LEN)
 
+        regex = tostring(regex)
         compiled = C.ngx_http_lua_ffi_compile_regex(regex, #regex, flags,
                                                     pcre_opts, errbuf,
                                                     MAX_ERR_MSG_LEN)

--- a/t/re-match.t
+++ b/t/re-match.t
@@ -569,12 +569,12 @@ attempt to get length of local 'subj' (a number value)
 
 
 
-=== TEST 15: subject is not a string type
+=== TEST 15: regex is not a string type
 --- http_config eval: $::HttpConfig
 --- config
     location /re {
         content_by_lua_block {
-            local m = ngx.re.match(12345, "123", "jo")
+            local m = ngx.re.match(12345, 123, "jo")
 
             if m then
                 ngx.say(m[0])

--- a/t/re-sub.t
+++ b/t/re-sub.t
@@ -393,3 +393,41 @@ hello, 55
 --- no_error_log
 [error]
 attempt to get length of local 'bit' (a number value)
+
+
+
+=== TEST 12: regex is not a string type (ngx.re.sub)
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            local newstr, n, err = ngx.re.sub(1234, 12, 5, "jo")
+            ngx.say(newstr)
+        }
+    }
+--- request
+GET /re
+--- response_body
+534
+--- no_error_log
+[error]
+attempt to get length of local 'regex' (a number value)
+
+
+
+=== TEST 13: regex is not a string type (ngx.re.gsub)
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            local newstr, n, err = ngx.re.gsub(123412, 12, 5, "jo")
+            ngx.say(newstr)
+        }
+    }
+--- request
+GET /re
+--- response_body
+5345
+--- no_error_log
+[error]
+attempt to get length of local 'regex' (a number value)


### PR DESCRIPTION
It seems to be a miss of a previous bugfix.

When we execute `ngx.re.match("1234", 123, "jo")`:
With lua-resty-core, there would be a `attempt to get length of local 'regex' (a number value)` error.
Without lua-resty-core, there would be `123` and everything is ok.

The same with `ngx.re.sub("1234", 123, 456, "jo")`.

This pr eliminates the difference and makes the behavior consistent.

I hereby granted the copyright of the changes in this pull request
to the authors of this project.