### PR TITLE
feature: ngx.errlog: added the raw_log() API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b feat/rawlog https://github.com/thibaultcha/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -14,6 +14,7 @@ Table of Contents
     * [set_filter_level](#set_filter_level)
     * [get_logs](#get_logs)
     * [get_sys_filter_level](#get_sys_filter_level)
+    * [raw_log](#raw_log)
 * [Community](#community)
     * [English Mailing List](#english-mailing-list)
     * [Chinese Mailing List](#chinese-mailing-list)
@@ -250,6 +251,108 @@ if not status then
     return
 end
 ```
+
+[Back to TOC](#table-of-contents)
+
+raw_log
+-------
+**syntax:** *log_module.raw_log(log_level, msg)*
+
+**context:** *any*
+
+Log `msg` to the error logs with the given logging level.
+
+Just like the [ngx.log](https://github.com/openresty/lua-nginx-module#ngxlog)
+API, the `log_level` argument can take constants like `ngx.ERR` and `ngx.WARN`.
+Check out [Nginx log level constants for
+details.](https://github.com/openresty/lua-nginx-module#nginx-log-level-constants)
+
+However, unlike the `ngx.log` API which accepts variadic arguments, this
+function only accepts a single string as its second argument `msg`.
+
+This function differs from `ngx.log` in the way that it will not prefix the
+written logs with any sort of debug information (such as the caller's file
+and line number).
+
+For example, while `ngx.log` would produce the following:
+
+```
+ngx.log(ngx.NOTICE, "hello world")
+
+2017/07/09 19:36:25 [notice] 25932#0: *1 [lua] content_by_lua(nginx.conf:51):5: hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
+```
+
+`errlog.raw_log` produces:
+
+```
+local errlog = require "ngx.errlog"
+errlog.raw_log(ngx.NOTICE, "hello world")
+
+2017/07/09 19:36:25 [notice] 25932#0: *1 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
+```
+
+This function is best suited when the format and/or stack level of the debug
+information proposed by `ngx.log` is not desired. A good example of this would
+be a custom logging function which prefixes each log with a namespace in
+an application:
+
+```
+1.  local function my_log(lvl, ...)
+2.      ngx.log(lvl, "[prefix] ", ...)
+3.  end
+4.
+5.  my_log(ngx.ERR, "error")
+```
+
+Here, the produced log would indicate that this error was logged at line `2.`,
+when in reality, we wish the investigator of that log to realize it was logged
+at line `5.` right away.
+
+For such use cases (or other formatting reasons), one may use `raw_log` to
+create a logging utility that supports such requirements. Here is a suggested
+implementation:
+
+```lua
+local errlog = require "ngx.errlog"
+
+local function my_log(lvl, ...)
+  -- log to error logs with our custom prefix, stack level
+  -- and separator
+  local n = select("#", ...)
+  local t = { ... }
+  local info = debug.getinfo(2, "Sl")
+
+  local prefix = string.format("(%s):%d:", info.short_src, info.currentline)
+  local buf = { prefix }
+
+  for i = 1, n do
+    buf[i + 1] = tostring(t[i])
+  end
+
+  local msg = table.concat(buf, " ")
+
+  errlog.raw_log(lvl, msg) -- line 19.
+end
+
+local function my_function()
+  -- do something and log
+
+  my_log(ngx.ERR, "hello from", "raw_log:", true) -- line 25.
+end
+
+my_function()
+```
+
+This utility function will produce the following log, explicitly stating that
+the error was logged on line `25.`:
+
+```
+2017/07/09 20:03:07 [error] 26795#0: *2 (/path/to/file.lua):25: hello from raw_log: true, context: ngx.timer
+```
+
+As a reminder to the reader, one must be wary of the cost of string
+concatenation on the Lua land, and should prefer the combined use of a buffer
+table and `table.concat` to avoid unnecessary GC pressure.
 
 [Back to TOC](#table-of-contents)
 

--- a/t/errlog-raw-log.t
+++ b/t/errlog-raw-log.t
@@ -1,0 +1,222 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+log_level('error');
+
+repeat_each(1);
+
+plan tests => repeat_each() * (blocks() * 2 + 5);
+
+my $pwd = cwd();
+
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    my $http_config = $block->http_config || '';
+    my $init_by_lua_block = $block->init_by_lua_block || 'require "resty.core"';
+
+    $http_config .= <<_EOC_;
+
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+    init_by_lua_block {
+        $init_by_lua_block
+        local errlog_file = "$Test::Nginx::Util::ErrLogFile"
+    }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: errlog.raw_log with bad log level (ngx.ERROR, -1)
+--- config
+    location /log {
+        content_by_lua_block {
+            local errlog = require "ngx.errlog"
+
+            errlog.raw_log(ngx.ERROR, "hello, log")
+            ngx.say("done")
+        }
+    }
+--- request
+GET /log
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log
+bad log level: -1
+
+
+
+=== TEST 2: errlog.raw_log with bad levels (9)
+--- config
+    location /log {
+        content_by_lua_block {
+            local errlog = require "ngx.errlog"
+
+            errlog.raw_log(9, "hello, log")
+            ngx.say("done")
+        }
+    }
+--- request
+GET /log
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log
+bad log level: 9
+
+
+
+=== TEST 3: errlog.raw_log with bad log message
+--- config
+    location /log {
+        content_by_lua_block {
+            local errlog = require "ngx.errlog"
+
+            errlog.raw_log(ngx.ERR, 123)
+            ngx.say("done")
+        }
+    }
+--- request
+GET /log
+--- response_body_like: 500 Internal Server Error
+--- error_code: 500
+--- error_log
+bad argument #2 to 'raw_log' (must be a string)
+
+
+
+=== TEST 4: errlog.raw_log test log-level ERR
+--- config
+    location /log {
+        content_by_lua_block {
+            local errlog = require "ngx.errlog"
+
+            errlog.raw_log(ngx.ERR, "hello world")
+        }
+    }
+--- request
+GET /log
+--- error_log eval
+qr/\[error\] \S+: \S+ hello world/
+
+
+
+=== TEST 5: errlog.raw_log JITs
+--- init_by_lua_block
+    -- local verbose = true
+    local verbose = false
+    local outfile = errlog_file
+    -- local outfile = "/tmp/v.log"
+    if verbose then
+        local dump = require "jit.dump"
+        dump.on(nil, outfile)
+    else
+        local v = require "jit.v"
+        v.on(outfile)
+    end
+
+    require "resty.core"
+    -- jit.opt.start("hotloop=1")
+    -- jit.opt.start("loopunroll=1000000")
+    -- jit.off()
+--- config
+    location /log {
+        content_by_lua_block {
+            local errlog = require "ngx.errlog"
+
+            for i = 1, 100 do
+                errlog.raw_log(ngx.ERR, "hello world")
+            end
+        }
+    }
+--- request
+GET /log
+--- error_log eval
+qr/\[TRACE   \d+ content_by_lua\(nginx.conf:\d+\):4 loop\]/
+
+
+
+=== TEST 6: errlog.raw_log in init_by_lua
+--- init_by_lua_block
+    local errlog = require "ngx.errlog"
+    errlog.raw_log(ngx.ERR, "hello world from init_by_lua")
+--- config
+    location /t {
+        return 200;
+    }
+--- request
+GET /t
+--- grep_error_log chop
+hello world from init_by_lua
+--- grep_error_log_out eval
+["hello world from init_by_lua\n", ""]
+
+
+
+=== TEST 7: errlog.raw_log in init_worker_by_lua
+--- http_config
+    init_worker_by_lua_block {
+        local errlog = require "ngx.errlog"
+        errlog.raw_log(ngx.ERR, "hello world from init_worker_by_lua")
+    }
+--- config
+    location /t {
+        return 200;
+    }
+--- request
+GET /t
+--- grep_error_log chop
+hello world from init_worker_by_lua
+--- grep_error_log_out eval
+["hello world from init_worker_by_lua\n", ""]
+
+
+
+=== TEST 8: errlog.raw_log with \0 in the log message
+--- config
+    location /log {
+        content_by_lua_block {
+            local errlog = require "ngx.errlog"
+            errlog.raw_log(ngx.ERR, "hello\0world")
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /log
+--- response_body
+ok
+--- error_log eval
+"hello\0world, client: "
+
+
+
+=== TEST 9: errlog.raw_log is captured by errlog.get_logs()
+--- http_config
+    lua_capture_error_log 4k;
+--- config
+    location /log {
+        content_by_lua_block {
+            local errlog = require "ngx.errlog"
+            errlog.raw_log(ngx.ERR, "hello from raw_log()")
+
+            local res, err = errlog.get_logs()
+            if not res then
+                error("FAILED " .. err)
+            end
+
+            ngx.say("log lines: ", #res / 3)
+        }
+    }
+--- request
+GET /log
+--- response_body
+log lines: 1
+--- error_log eval
+qr/\[error\] .*? hello from raw_log\(\)/
+--- skip_nginx: 3: <1.11.2


### PR DESCRIPTION
This adds the `errlog.rawlog()` API function to allow for custom logging facilities, as discussed in openresty/lua-nginx-module#1074.

Its signature is:

```lua
errlog.rawlog(lvl, msg)
```

The second argument `msg` must be a string. This is a deliberate choice vs providing a variadic function like `ngx.log(lvl, ...)`,  to defer all formatting decisions (separator, string coertion, `__tostring()` call, ...) to the user when developing his or her logging facility.

Let me know your thoughts, and when everything will be agreed upon I will provide the documentation for this API.

