### PR TITLE
doc: added a performance note for set_cert & set_priv_key 

### DIFF
--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -369,7 +369,7 @@ Sets the SSL certificate chain opaque pointer returned by the
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
 
-Note that the `set_cert` function will perform slightly better, in terms of CPU cycles wasted, than then
+Note that the `set_cert` function will perform slightly better, in terms of CPU cycles wasted, than the
 [set_der_cert](#set_der_cert) variant, since the first function uses opaque cdata pointers
 which do not require any additional conversion needed to be performed by the NGINX core during the SSL session
 negotiation.
@@ -389,7 +389,7 @@ Sets the SSL private key opaque pointer returned by the
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
 
-Note that the `set_priv_key` function will perform slightly better, in terms of CPU cycles wasted, than then
+Note that the `set_priv_key` function will perform slightly better, in terms of CPU cycles wasted, than the
 [set_der_priv_key](#set_der_priv_key) variant, since the first function uses opaque cdata pointers
 which do not require any additional conversion needed to be performed by the NGINX core during the SSL session
 negotiation.

--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -369,6 +369,10 @@ Sets the SSL certificate chain opaque pointer returned by the
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
 
+Note, that the [set_cert](#set_cert) function will perform slightly better, in terms of CPU cycles wasted, than then
+[set_der_cert](#set_der_cert) variant, since the first function uses opaque cdata pointers
+which do not require any additional conversion needed to be performed by the NGINX core via the OpenSSL module.
+
 This function was first added in version `0.1.7`.
 
 [Back to TOC](#table-of-contents)
@@ -383,6 +387,10 @@ Sets the SSL private key opaque pointer returned by the
 [parse_pem_priv_key](#parse_pem_priv_key) function for the current SSL connection.
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
+
+Note, that the [set_priv_key](#set_priv_key) function will perform slightly better, in terms of CPU cycles wasted, than then
+[set_der_priv_key](#set_der_priv_key) variant, since the first function uses opaque cdata pointers
+which do not require any additional conversion needed to be performed by the NGINX core via the OpenSSL module.
 
 This function was first added in version `0.1.7`.
 

--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -369,9 +369,10 @@ Sets the SSL certificate chain opaque pointer returned by the
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
 
-Note, that the [set_cert](#set_cert) function will perform slightly better, in terms of CPU cycles wasted, than then
+Note that the `set_cert` function will perform slightly better, in terms of CPU cycles wasted, than then
 [set_der_cert](#set_der_cert) variant, since the first function uses opaque cdata pointers
-which do not require any additional conversion needed to be performed by the NGINX core via the OpenSSL module.
+which do not require any additional conversion needed to be performed by the NGINX core during the SSL session
+negotiation.
 
 This function was first added in version `0.1.7`.
 
@@ -388,9 +389,10 @@ Sets the SSL private key opaque pointer returned by the
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
 
-Note, that the [set_priv_key](#set_priv_key) function will perform slightly better, in terms of CPU cycles wasted, than then
+Note that the `set_priv_key` function will perform slightly better, in terms of CPU cycles wasted, than then
 [set_der_priv_key](#set_der_priv_key) variant, since the first function uses opaque cdata pointers
-which do not require any additional conversion needed to be performed by the NGINX core via the OpenSSL module.
+which do not require any additional conversion needed to be performed by the NGINX core during the SSL session
+negotiation.
 
 This function was first added in version `0.1.7`.
 


### PR DESCRIPTION
Hi,

I added a simple note to the `set_cert` and `set_priv_key` functions regarding the performance benefit they provide if compared to the  `set_der_cert` and `set_der_priv_key` variants.

(more info [here](https://groups.google.com/forum/#!topic/openresty-en/VEXG8w0sbp0))

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

Thanks!