### PR TITLE
luacheck: added 'ngx' as a global

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,5 @@
 std = 'ngx_lua'
+globals = { 'ngx' }
 unused_args = false
 read_globals = {
     "coroutine._yield"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,13 @@ env:
     - LD_LIBRARY_PATH=$LUAJIT_LIB:$LD_LIBRARY_PATH
     - TEST_NGINX_SLEEP=0.005
     - TEST_NGINX_RANDOMIZE=1
+    - LUACHECK_VER=0.21.1
   matrix:
     - NGINX_VERSION=1.9.15
     - NGINX_VERSION=1.11.2
 
 before_install:
-  - sudo luarocks install luacheck
+  - sudo luarocks install luacheck $LUACHECK_VER
   - luacheck -q .
   - '! grep -n -P ''(?<=.{80}).+'' --color `find . -name ''*.lua''` || (echo "ERROR: Found Lua source lines exceeding 80 columns." > /dev/stderr; exit 1)'
   - '! grep -n -P ''\t+'' --color `find . -name ''*.lua''` || (echo "ERROR: Cannot use tabs." > /dev/stderr; exit 1)'


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

It seems like since https://github.com/mpeterv/luacheck/commit/ca438ef972ece82160311920740d316b129ce7d4 was released by
Luacheck, the linting fails in Travis-CI because of this module
overriding variables attached to the `ngx` global.