### PR TITLE
consume errlen so we don't use garbage pass end of string

### DIFF
--- a/lib/resty/core/var.lua
+++ b/lib/resty/core/var.lua
@@ -25,7 +25,7 @@ ffi.cdef[[
     int ngx_http_lua_ffi_var_set(ngx_http_request_t *r,
         const unsigned char *name_data, size_t name_len,
         unsigned char *lowcase_buf, const unsigned char *value,
-        size_t value_len, unsigned char *errbuf, size_t errlen);
+        size_t value_len, unsigned char *errbuf, size_t *errlen);
 ]]
 
 
@@ -84,8 +84,9 @@ local function var_set(self, name, value)
     end
     local name_len = #name
 
-    local errlen = 256
-    local lowcase_buf = get_string_buf(name_len + errlen)
+    local errlen = get_size_ptr()
+    errlen[0] = 256
+    local lowcase_buf = get_string_buf(name_len + errlen[0])
 
     local value_len
     if value == nil then
@@ -108,7 +109,7 @@ local function var_set(self, name, value)
     end
 
     if rc == -1 then  -- NGX_ERROR
-        return error(ffi_str(errbuf, errlen))
+        return error(ffi_str(errbuf, errlen[0]))
     end
 end
 


### PR DESCRIPTION
counterpart of https://github.com/openresty/lua-nginx-module/pull/1165

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
