### PR TITLE
bugfix: ngx.re: fix an edge-case where split() might not destroy  compiled regexes

### DIFF
--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -129,7 +129,7 @@ function _M.split(subj, regex, opts, ctx, max, res)
         res = new_tab(narr, 0)
 
     elseif type(res) ~= "table" then
-        return error("res is not a table", 2)
+        error("res is not a table", 2)
     end
 
     local len = #subj

--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -53,9 +53,6 @@ local function re_split_helper(subj, compiled, compile_once, flags, ctx)
     end
 
     if rc == PCRE_ERROR_NOMATCH then
-        if not compile_once then
-            destroy_compiled_regex(compiled)
-        end
         return nil, nil, nil
     end
 
@@ -68,6 +65,9 @@ local function re_split_helper(subj, compiled, compile_once, flags, ctx)
 
     if rc == 0 then
         if band(flags, FLAG_DFA) == 0 then
+            if not compile_once then
+                destroy_compiled_regex(compiled)
+            end
             return nil, nil, nil, "capture size too small"
         end
 
@@ -192,12 +192,6 @@ function _M.split(subj, regex, opts, ctx, max, res)
             end
         end
 
-        if count == max then
-            if not compile_once then
-                destroy_compiled_regex(compiled)
-            end
-        end
-
     else
         while true do
             local from, to, capture, err = re_split_helper(subj, compiled,
@@ -235,6 +229,10 @@ function _M.split(subj, regex, opts, ctx, max, res)
             end
         end
 
+    end
+
+    if not compile_once then
+        destroy_compiled_regex(compiled)
     end
 
     -- trailing nil for non-cleared res tables


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

I might be wrong, but it seems to me like we are missing some calls to `destroy_compiled_regex()` when we get the `"capture size too small"` error and when we exit naturally from the "non-max" loop (the second one).

This unifies the compiled regex destruction like so:
- Any error encountered while the regex executes makes `re_split_helper()` destroy the regex before returning `nil, err`
- If the loops terminate normally, `split()` will destroy the compiled regex before returning `res`

---

(The error tail call is a minor change I noticed while doing this change, and iirc, we try to avoid this pattern now - the combination of a tail call and a level argument of `2` would be problematic anyways)