### PR TITLE
small typo fix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,7 +78,7 @@ as proper Lua modules, like [ngx.semaphore](#ngxsemaphore) and [ngx.balancer](#n
 The FFI-based Lua API can work with LuaJIT's JIT compiler. ngx_lua's default API is based on the standard
 Lua C API, which will never be JIT compiled and the user Lua code is always interpreted (slowly).
 
-Suppor for the new [ngx_stream_lua_module](https://github.com/openresty/stream-lua-nginx-module) has also begun.
+Support for the new [ngx_stream_lua_module](https://github.com/openresty/stream-lua-nginx-module) has also begun.
 
 This library is shipped with the OpenResty bundle by default. So you do not really need to worry about the dependencies
 and requirements.


### PR DESCRIPTION
In Readme.markdown there is a small typo "Suppor", should be "Support".