### PR TITLE
bugfix: library loaded by package.path should be installed under share/lua and LUA_VERSION is required.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 OPENRESTY_PREFIX=/usr/local/openresty
 
-#LUA_VERSION := 5.1
+LUA_VERSION := 5.1
 PREFIX ?=          /usr/local
 LUA_INCLUDE_DIR ?= $(PREFIX)/include
-LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
+LUA_LIB_DIR ?=     $(PREFIX)/share/lua/$(LUA_VERSION)
 INSTALL ?= install
 
 .PHONY: all test install


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
