### PR TITLE
feature : add a shortcut to ngx.re.split and ngx.re.opt

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,7 +78,7 @@ as proper Lua modules, like [ngx.semaphore](#ngxsemaphore) and [ngx.balancer](#n
 The FFI-based Lua API can work with LuaJIT's JIT compiler. ngx_lua's default API is based on the standard
 Lua C API, which will never be JIT compiled and the user Lua code is always interpreted (slowly).
 
-Suppor for the new [ngx_stream_lua_module](https://github.com/openresty/stream-lua-nginx-module) has also begun.
+Support for the new [ngx_stream_lua_module](https://github.com/openresty/stream-lua-nginx-module) has also begun.
 
 This library is shipped with the OpenResty bundle by default. So you do not really need to worry about the dependencies
 and requirements.

--- a/lib/resty/core.lua
+++ b/lib/resty/core.lua
@@ -17,6 +17,10 @@ if subsystem == 'http' then
     require "resty.core.response"
     require "resty.core.time"
     require "resty.core.worker"
+
+    local ngx_re = require "ngx.re"
+    ngx.re.split = ngx_re.split
+    ngx.re.opt = ngx_re.opt
 end
 
 


### PR DESCRIPTION
ngx.re.split is a very nice method, but before we use it we must write 'require', it feels a little noisy.

So I put some code in 'resty.core.lua', add 'split' and 'opt' to the table 'ngx.re'. Then we can use split method just like its brothers 'match' or 'gmatch'.

For example:
ngx.re.split(...)   -- do not need any require

Do you think it is useful or helpful?
