### PR TITLE
Update balancer.t

### DIFF
--- a/t/balancer.t
+++ b/t/balancer.t
@@ -332,7 +332,7 @@ last peer failure: failed 500
 --- response_body_like: 503 Service Temporarily Unavailable
 --- error_code: 503
 --- grep_error_log eval: qr{last peer failure: \S+ \S+}
---- grep_error_log_out
+--- grep_error_log_out eval
 qr{last peer failure: nil nil
 last peer failure: failed 50[23]
 last peer failure: failed 50[23]}

--- a/t/balancer.t
+++ b/t/balancer.t
@@ -334,8 +334,8 @@ last peer failure: failed 500
 --- grep_error_log eval: qr{last peer failure: \S+ \S+}
 --- grep_error_log_out
 last peer failure: nil nil
-last peer failure: failed 502
-last peer failure: failed 502
+last peer failure: failed 503
+last peer failure: failed 503
 
 --- no_error_log
 [warn]

--- a/t/balancer.t
+++ b/t/balancer.t
@@ -333,9 +333,9 @@ last peer failure: failed 500
 --- error_code: 503
 --- grep_error_log eval: qr{last peer failure: \S+ \S+}
 --- grep_error_log_out
-last peer failure: nil nil
-last peer failure: failed 503
-last peer failure: failed 503
+qr{last peer failure: nil nil
+last peer failure: failed 50[23]
+last peer failure: failed 50[23]}
 
 --- no_error_log
 [warn]


### PR DESCRIPTION
This PR could be applied after the lua-resty-core supports nginx v1.13.7. The patch https://github.com/nginx/nginx/commit/f1be23bc8aed6c6e6bbba1320d85a8943550b253 fixes the proxy returns 503/504 rather than 502 if proxy_next_upstream includes http_503/http_504.