### PR TITLE
ngx.process.master_pid

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,7 +78,7 @@ as proper Lua modules, like [ngx.semaphore](#ngxsemaphore) and [ngx.balancer](#n
 The FFI-based Lua API can work with LuaJIT's JIT compiler. ngx_lua's default API is based on the standard
 Lua C API, which will never be JIT compiled and the user Lua code is always interpreted (slowly).
 
-Suppor for the new [ngx_stream_lua_module](https://github.com/openresty/stream-lua-nginx-module) has also begun.
+Support for the new [ngx_stream_lua_module](https://github.com/openresty/stream-lua-nginx-module) has also begun.
 
 This library is shipped with the OpenResty bundle by default. So you do not really need to worry about the dependencies
 and requirements.

--- a/lib/ngx/process.lua
+++ b/lib/ngx/process.lua
@@ -31,6 +31,7 @@ ffi.cdef[[
 int ngx_http_lua_ffi_enable_privileged_agent(char **err);
 int ngx_http_lua_ffi_get_process_type(void);
 void ngx_http_lua_ffi_process_signal_graceful_exit(void);
+int ngx_http_lua_ffi_master_pid(void);
 ]]
 
 
@@ -57,6 +58,11 @@ end
 
 function _M.signal_graceful_exit()
     C.ngx_http_lua_ffi_process_signal_graceful_exit()
+end
+
+
+function _M.master_pid()
+    return C.ngx_http_lua_ffi_master_pid()
 end
 
 

--- a/lib/ngx/process.lua
+++ b/lib/ngx/process.lua
@@ -62,7 +62,12 @@ end
 
 
 function _M.master_pid()
-    return C.ngx_http_lua_ffi_master_pid()
+    local pid = C.ngx_http_lua_ffi_master_pid()
+    if pid < 0 then
+        return nil
+    end
+
+    return pid
 end
 
 

--- a/t/process-master-pid.t
+++ b/t/process-master-pid.t
@@ -68,7 +68,7 @@ GET /t
 ^true
 \d+$
 --- error_log eval
-qr/\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
+qr/\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):\d loop\]/
 --- no_error_log
 [error]
  -- NYI:

--- a/t/process-master-pid.t
+++ b/t/process-master-pid.t
@@ -50,12 +50,22 @@ __DATA__
             for i = 1, 400 do
                 v = pid()
             end
+
+            local f = io.open(ngx.config.prefix().."/logs/nginx.pid", "r")
+            if not f then
+                ngx.say(false)
+            else
+                local str = f:read("*l")
+                ngx.say(v == tonumber(str or "0"))
+                f:close()
+            end
             ngx.say(v)
         }
     }
 --- request
 GET /t
 --- response_body_like chop
+^true
 \d+$
 --- error_log eval
 qr/\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/

--- a/t/process-master-pid.t
+++ b/t/process-master-pid.t
@@ -1,0 +1,68 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 6);
+
+my $pwd = cwd();
+
+our $HttpConfig = <<_EOC_;
+    lua_shared_dict dogs 1m;
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+    init_by_lua_block {
+        local verbose = false
+        if verbose then
+            local dump = require "jit.dump"
+            dump.on("b", "$Test::Nginx::Util::ErrLogFile")
+        else
+            local v = require "jit.v"
+            v.on("$Test::Nginx::Util::ErrLogFile")
+        end
+
+        require "resty.core"
+        -- jit.off()
+    }
+_EOC_
+
+#no_diff();
+#no_long_string();
+check_accum_error_log();
+run_tests();
+
+__DATA__
+
+=== TEST 1: ngx.process.master_pid
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local process = require "ngx.process"
+
+            local v
+            local pid = process.master_pid
+            for i = 1, 400 do
+                v = pid()
+            end
+            ngx.say(v)
+        }
+    }
+--- request
+GET /t
+--- response_body_like chop
+\d+$
+--- error_log eval
+qr/\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
+--- no_error_log
+[error]
+ -- NYI:
+ stitch
+
+
+


### PR DESCRIPTION
Here is the new API `ngx.process.master_pid`, which needs ffi C function `ngx_http_lua_ffi_master_pid` in ngx_lua.

I also write a test case in` t/process-master-pid.t`, But I am not familar with Perl and have not found the detail API documents of test::nginx, so I just copied `worker.t` then modified on it.

That test case may has error, please help me to correct it. Thanks very much.
