### PR TITLE
tests: removed invalid tail in lua_package_path.

### DIFF
--- a/t/ocsp.t
+++ b/t/ocsp.t
@@ -25,7 +25,7 @@ __DATA__
 
 === TEST 1: get OCSP responder (good case)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -112,7 +112,7 @@ OCSP url found: http://127.0.0.1:8888/ocsp?foo=1,
 
 === TEST 2: get OCSP responder (not found)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -203,7 +203,7 @@ OCSP responder not found
 
 === TEST 3: get OCSP responder (no issuer cert at all)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -293,7 +293,7 @@ failed to get OCSP responder: no issuer certificate in chain
 
 === TEST 4: get OCSP responder (issuer cert not next to the leaf cert)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -383,7 +383,7 @@ failed to get OCSP responder: issuer certificate not next to leaf
 
 === TEST 5: get OCSP responder (truncated)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -479,7 +479,7 @@ still get an error: truncated
 
 === TEST 6: create OCSP request (good)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -573,7 +573,7 @@ OCSP request created with length 68
 
 === TEST 7: create OCSP request (buffer too small)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -664,7 +664,7 @@ failed to create OCSP request: output buffer too small: 68 > 67
 
 === TEST 8: create OCSP request (empty string cert chain)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -746,7 +746,7 @@ failed to create OCSP request: d2i_X509_bio() failed
 
 === TEST 9: create OCSP request (no issuer cert in the chain)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -837,7 +837,7 @@ failed to create OCSP request: no issuer certificate in chain
 
 === TEST 10: validate good OCSP response
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -928,7 +928,7 @@ OCSP response validation ok
 
 === TEST 11: fail to validate OCSP response - no issuer cert
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1019,7 +1019,7 @@ OCSP response validation ok
 
 === TEST 12: validate good OCSP response - no certs in response
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1113,7 +1113,7 @@ OCSP response validation ok
 FIXME: we should complain in this case.
 
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1205,7 +1205,7 @@ OCSP response validation ok
 === TEST 14: fail to validate OCSP response - OCSP response signed by an unknown cert and the OCSP response does not contain the unknown cert
 
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1296,7 +1296,7 @@ OCSP response validation ok
 
 === TEST 15: fail to validate OCSP response - OCSP response returns revoked status
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1388,7 +1388,7 @@ OCSP response validation ok
 === TEST 16: good status req from client
 FIXME: check the OCSP staple actually received by the ssl client
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.2:8080 ssl;
@@ -1470,7 +1470,7 @@ ocsp status resp set ok: nil,
 
 === TEST 17: no status req from client
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.2:8080 ssl;

--- a/t/ssl-session-fetch.t
+++ b/t/ssl-session-fetch.t
@@ -30,7 +30,7 @@ __DATA__
 
 === TEST 1: get resume session id serialized
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
     ssl_session_fetch_by_lua_block {
         local ssl = require "ngx.ssl.session"
         local sid = ssl.get_session_id()
@@ -111,7 +111,7 @@ qr/ssl_session_fetch_by_lua_block:4: session id: [a-fA-f\d]+/s,
 
 === TEST 2: attempt to fetch new session in lua_ctx during resumption.
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
     ssl_session_fetch_by_lua_block {
         local ssl = require "ngx.ssl.session"
         local sess, err = ssl.get_serialized_session()
@@ -202,7 +202,7 @@ qr/ssl_session_fetch_by_lua:\d: session size: [a-fA-f\d]+|get session error: bad
 Use a tmp file to store and resume session. This is for testing only.
 In practice, never store session in plaintext on persistent storage.
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
     ssl_session_store_by_lua_block {
         local ssl = require "ngx.ssl.session"
 
@@ -303,7 +303,7 @@ qr/ssl_session_fetch_by_lua_block:4: session id: [a-fA-F\d]+/s,
 Session resumption should fail, but the handshake should be
 able to carry on and negotiate a new session.
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
     ssl_session_store_by_lua_block {
         local ssl = require "ngx.ssl.session"
 

--- a/t/ssl-session-store.t
+++ b/t/ssl-session-store.t
@@ -30,7 +30,7 @@ __DATA__
 
 === TEST 1: get new session serialized
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
     ssl_session_store_by_lua_block {
         local ssl = require "ngx.ssl.session"
         local sess = ssl.get_serialized_session()
@@ -102,7 +102,7 @@ qr/ssl_session_store_by_lua_block:4: session size: \d+/s
 
 === TEST 2: get new session id serialized
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
     ssl_session_store_by_lua_block {
         local ssl = require "ngx.ssl.session"
         local sid = ssl.get_session_id()
@@ -174,7 +174,7 @@ qr/ssl_session_store_by_lua_block:4: session id: [a-fA-f\d]+/s
 
 === TEST 3: store the session via timer to memcached
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
     ssl_session_store_by_lua_block {
         local ssl = require "ngx.ssl.session"
         local function f(premature, key, value)

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -25,7 +25,7 @@ __DATA__
 
 === TEST 1: clear certs
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -115,7 +115,7 @@ sslv3 alert handshake failure
 
 === TEST 2: set DER cert and private key
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -235,7 +235,7 @@ lua ssl server name: "test.com"
 
 === TEST 3: read SNI name via ssl.server_name()
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -334,7 +334,7 @@ read SNI name from Lua: test.com
 
 === TEST 4: read SNI name via ssl.server_name() when no SNI name specified
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -434,7 +434,7 @@ read SNI name from Lua: nil, type: nil
 
 === TEST 5: read raw server addr via ssl.raw_server_addr() (unix domain socket)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -553,7 +553,7 @@ qr/Using unix socket file .*?nginx\.sock/
 
 === TEST 6: read raw server addr via ssl.raw_server_addr() (IPv4)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.1:12345 ssl;
@@ -672,7 +672,7 @@ Using IPv4 address: 127.0.0.1
 
 === TEST 7: read raw server addr via ssl.raw_server_addr() (IPv6)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen [::1]:12345 ssl;
@@ -792,7 +792,7 @@ Using IPv6 address: 0.0.0.1
 
 === TEST 8: set DER cert chain
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -913,7 +913,7 @@ lua ssl server name: "test.com"
 
 === TEST 9: read PEM cert chain but set DER cert chain
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1040,7 +1040,7 @@ lua ssl server name: "test.com"
 
 === TEST 10: tls version - SSLv3
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.2:8080 ssl;
@@ -1116,7 +1116,7 @@ got TLS1 version: SSLv3,
 
 === TEST 11: tls version - TLSv1
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.2:8080 ssl;
@@ -1192,7 +1192,7 @@ got TLS1 version: TLSv1,
 
 === TEST 12: tls version - TLSv1.1
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.2:8080 ssl;
@@ -1268,7 +1268,7 @@ got TLS1 version: TLSv1.1,
 
 === TEST 13: tls version - TLSv1.2
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.2:8080 ssl;
@@ -1344,7 +1344,7 @@ got TLS1 version: TLSv1.2,
 
 === TEST 14: ngx.semaphore in ssl_certificate_by_lua*
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.2:8080 ssl;
@@ -1433,7 +1433,7 @@ ssl cert by lua done
 
 === TEST 15: read PEM key chain but set DER key chain
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1565,7 +1565,7 @@ lua ssl server name: "test.com"
 
 === TEST 16: parse PEM cert and key to cdata
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1698,7 +1698,7 @@ lua ssl server name: "test.com"
 
 === TEST 17: parse PEM cert and key to cdata (bad cert 0 in the chain)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1822,7 +1822,7 @@ qr/\[error\] .*? failed to parse pem cert: PEM_read_bio_X509_AUX\(\) failed/
 
 === TEST 18: parse PEM cert and key to cdata (bad cert 2 in the chain)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -1946,7 +1946,7 @@ qr/\[error\] .*? failed to parse pem cert: PEM_read_bio_X509\(\) failed/
 
 === TEST 19: parse PEM cert and key to cdata (bad priv key)
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
@@ -2070,7 +2070,7 @@ qr/\[error\] .*? failed to parse pem key: PEM_read_bio_PrivateKey\(\) failed/
 
 === TEST 20: read client addr via ssl.raw_client_addr()
 --- http_config
-    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH/?.lua;;";
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
         listen 127.0.0.1:12345 ssl;


### PR DESCRIPTION
TEST_NGINX_LUA_PACKAGE_PATH already contains the '?.lua;;' file pattern part

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
