### PR TITLE
optimize: shdict: switched exptime argument type to 'long' to avoid potential overflows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b refactor/ttl-use-long-type https://github.com/thibaultcha/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/lib/resty/core/shdict.lua
+++ b/lib/resty/core/shdict.lua
@@ -34,16 +34,16 @@ ffi.cdef[[
     int ngx_http_lua_ffi_shdict_store(void *zone, int op,
         const unsigned char *key, size_t key_len, int value_type,
         const unsigned char *str_value_buf, size_t str_value_len,
-        double num_value, int exptime, int user_flags, char **errmsg,
+        double num_value, long exptime, int user_flags, char **errmsg,
         int *forcible);
 
     int ngx_http_lua_ffi_shdict_flush_all(void *zone);
 
-    int ngx_http_lua_ffi_shdict_get_ttl(void *zone,
-        const unsigned char *key, size_t key_len);
+    long ngx_http_lua_ffi_shdict_get_ttl(void *zone,
+         const unsigned char *key, size_t key_len);
 
     int ngx_http_lua_ffi_shdict_set_expire(void *zone,
-        const unsigned char *key, size_t key_len, int exptime);
+        const unsigned char *key, size_t key_len, long exptime);
 
     size_t ngx_http_lua_ffi_shdict_capacity(void *zone);
 ]]

--- a/t/shdict.t
+++ b/t/shdict.t
@@ -1528,3 +1528,111 @@ foo after init_ttl = nil
 [error]
 [alert]
 [crit]
+
+
+
+=== TEST 47: exptime uses long type to avoid overflow in set() + ttl()
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            dogs:flush_all()
+
+            local ok, err = dogs:set("huge_ttl", true, 2 ^ 31)
+            if not ok then
+                ngx.say("err setting: ", err)
+                return
+            end
+
+            local ttl, err = dogs:ttl("huge_ttl")
+            if not ttl then
+                ngx.say("err retrieving ttl: ", err)
+                return
+            end
+
+            ngx.say("ttl: ", ttl)
+        }
+    }
+--- request
+GET /t
+--- response_body
+ttl: 2147483648
+--- no_error_log
+[error]
+[alert]
+[crit]
+
+
+
+=== TEST 48: exptime uses long type to avoid overflow in expire() + ttl()
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            dogs:flush_all()
+
+            local ok, err = dogs:set("updated_huge_ttl", true)
+            if not ok then
+                ngx.say("err setting: ", err)
+                return
+            end
+
+            local ok, err = dogs:expire("updated_huge_ttl", 2 ^ 31)
+            if not ok then
+                ngx.say("err expire: ", err)
+                return
+            end
+
+            local ttl, err = dogs:ttl("updated_huge_ttl")
+            if not ttl then
+                ngx.say("err retrieving ttl: ", err)
+                return
+            end
+
+            ngx.say("ttl: ", ttl)
+        }
+    }
+--- request
+GET /t
+--- response_body
+ttl: 2147483648
+--- no_error_log
+[error]
+[alert]
+[crit]
+
+
+
+=== TEST 49: init_ttl uses long type to avoid overflow in incr() + ttl()
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            dogs:flush_all()
+
+            local ok, err = dogs:incr("incr_huge_ttl", 1, 0, 2 ^ 31)
+            if not ok then
+                ngx.say("err incr: ", err)
+                return
+            end
+
+            local ttl, err = dogs:ttl("incr_huge_ttl")
+            if not ttl then
+                ngx.say("err retrieving ttl: ", err)
+                return
+            end
+
+            ngx.say("ttl: ", ttl)
+        }
+    }
+--- request
+GET /t
+--- response_body
+ttl: 2147483648
+--- no_error_log
+[error]
+[alert]
+[crit]


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

Sister PR of https://github.com/openresty/lua-nginx-module/pull/1229