### PR TITLE
bugfix: ngx.re: fixed a split() edge-case when remaining characters is matched

### DIFF
--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -251,20 +251,18 @@ function _M.split(subj, regex, opts, ctx, max, res)
     -- trailing nil for non-cleared res tables
 
     -- delete empty trailing ones (without max)
-    local remaining_str = sub(subj, sub_idx)
-
-    if max <= 0 and remaining_str == "" then
+    if max <= 0 and sub_idx > len then
         for ety_idx = res_idx, 1, -1 do
-            if res[ety_idx] == "" then
-                res[ety_idx] = nil
-            else
+            if res[ety_idx] ~= "" then
                 res_idx = ety_idx
                 break
             end
+
+            res[ety_idx] = nil
         end
     else
         res_idx = res_idx + 1
-        res[res_idx] = remaining_str
+        res[res_idx] = sub(subj, sub_idx)
     end
 
     res[res_idx + 1] = nil

--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -201,8 +201,6 @@ function _M.split(subj, regex, opts, ctx, max, res)
 
                 if sub_idx > len then
                     break
-                elseif sub_idx == len and last_empty_match then
-                    break
                 end
             end
         end
@@ -240,8 +238,6 @@ function _M.split(subj, regex, opts, ctx, max, res)
 
                 if sub_idx > len then
                     break
-                elseif sub_idx == len and last_empty_match then
-                    break
                 end
             end
         end
@@ -263,14 +259,15 @@ function _M.split(subj, regex, opts, ctx, max, res)
                 res[ety_idx] = nil
             else
                 res_idx = ety_idx
-                res[res_idx + 1] = nil
                 break
             end
         end
     else
-        res[res_idx + 1] = remaining_str
-        res[res_idx + 2] = nil
+        res_idx = res_idx + 1
+        res[res_idx] = remaining_str
     end
+
+    res[res_idx + 1] = nil
 
     return res
 end

--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -199,7 +199,9 @@ function _M.split(subj, regex, opts, ctx, max, res)
 
                 sub_idx = to
 
-                if sub_idx >= len then
+                if sub_idx > len then
+                    break
+                elseif sub_idx == len and last_empty_match then
                     break
                 end
             end
@@ -236,7 +238,9 @@ function _M.split(subj, regex, opts, ctx, max, res)
 
                 sub_idx = to
 
-                if sub_idx >= len then
+                if sub_idx > len then
+                    break
+                elseif sub_idx == len and last_empty_match then
                     break
                 end
             end

--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -258,18 +258,15 @@ function _M.split(subj, regex, opts, ctx, max, res)
     local remaining_str = sub(subj, sub_idx)
 
     if max <= 0 and remaining_str == "" then
-        local ety_idx = res_idx
-
         for ety_idx = res_idx, 1, -1 do
             if res[ety_idx] == "" then
                 res[ety_idx] = nil
             else
+                res_idx = ety_idx
+                res[res_idx + 1] = nil
                 break
             end
         end
-
-        res_idx = ety_idx
-        res[res_idx + 1] = nil
     else
         res[res_idx + 1] = remaining_str
         res[res_idx + 2] = nil

--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -254,8 +254,26 @@ function _M.split(subj, regex, opts, ctx, max, res)
 
     -- trailing nil for non-cleared res tables
 
-    res[res_idx + 1] = sub(subj, sub_idx)
-    res[res_idx + 2] = nil
+    -- delete empty trailing ones (without max)
+    local remaining_str = sub(subj, sub_idx)
+
+    if max <= 0 and remaining_str == "" then
+        local ety_idx = res_idx
+
+        for ety_idx = res_idx, 1, -1 do
+            if res[ety_idx] == "" then
+                res[ety_idx] = nil
+            else
+                break
+            end
+        end
+
+        res_idx = ety_idx
+        res[res_idx + 1] = nil
+    else
+        res[res_idx + 1] = remaining_str
+        res[res_idx + 2] = nil
+    end
 
     return res
 end

--- a/t/re-split.t
+++ b/t/re-split.t
@@ -605,7 +605,6 @@ a
 b
 c
 d
-_blank_
 --- error_log eval
 qr/\[TRACE   \d+/
 --- no_error_log
@@ -1248,7 +1247,7 @@ qr/\[TRACE   \d+/
 
 
 
-=== TEST 38: remaining characters are matched by regex
+=== TEST 38: remaining characters are matched by regex (without max)
 --- http_config eval: $::HttpConfig
 --- config
     location /re {
@@ -1257,7 +1256,36 @@ qr/\[TRACE   \d+/
 
             local subj = "a,b,cd,,,"
 
-            for _, max in ipairs({0, 6}) do
+            local res, err = ngx_re.split(subj, ",")
+            if err then
+                ngx.log(ngx.ERR, "failed: ", err)
+                return
+            end
+
+            ngx.say(#res, " ", table.concat(res, "|"))
+        }
+    }
+--- request
+GET /re
+--- response_body
+3 a|b|cd
+--- error_log eval
+qr/\[TRACE   \d+/
+--- no_error_log
+[error]
+
+
+
+=== TEST 39: remaining characters are matched by regex (with max)
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            local ngx_re = require "ngx.re"
+
+            local subj = "a,b,cd,,,"
+
+            for max = 1, 7 do
                 local res, err = ngx_re.split(subj, ",", nil, nil, max)
                 if err then
                     ngx.log(ngx.ERR, "failed: ", err)
@@ -1271,6 +1299,11 @@ qr/\[TRACE   \d+/
 --- request
 GET /re
 --- response_body
+1 a,b,cd,,,
+2 a|b,cd,,,
+3 a|b|cd,,,
+4 a|b|cd|,,
+5 a|b|cd||,
 6 a|b|cd|||
 6 a|b|cd|||
 --- error_log eval

--- a/t/re-split.t
+++ b/t/re-split.t
@@ -1245,3 +1245,35 @@ GET /re
 qr/\[TRACE   \d+/
 --- no_error_log
 [error]
+
+
+
+=== TEST 38: remaining characters are matched by regex
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            local ngx_re = require "ngx.re"
+
+            local subj = "a,b,cd,,,"
+
+            for _, max in ipairs({0, 6}) do
+                local res, err = ngx_re.split(subj, ",", nil, nil, max)
+                if err then
+                    ngx.log(ngx.ERR, "failed: ", err)
+                    return
+                end
+
+                ngx.say(#res, " ", table.concat(res, "|"))
+            end
+        }
+    }
+--- request
+GET /re
+--- response_body
+6 a|b|cd|||
+6 a|b|cd|||
+--- error_log eval
+qr/\[TRACE   \d+/
+--- no_error_log
+[error]


### PR DESCRIPTION
when `re_split_helper` traverse the subject string, the remaining characters are push to array `res`, forgot to check the remaining characters whether matched by regex.

reproduce
---

``` lua
local ngx_re = require "ngx.re"
local res, err = ngx_re.split("a,b,cd,,,", ",")

ngx.say(#res)  
-- output is 5
-- it shoule be 6 here

ngx.say(table.concat(res, "|")) 
-- outout is a|b|cd||, 
-- it should be a|b|cd|||
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
