### PR TITLE
improvement: replaced `return error()` with `error()`

### DIFF
--- a/lib/ngx/balancer.lua
+++ b/lib/ngx/balancer.lua
@@ -106,7 +106,7 @@ local _M = { version = base.version }
 function _M.set_current_peer(addr, port)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if not port then
@@ -128,7 +128,7 @@ end
 function _M.set_more_tries(count)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = ngx_lua_ffi_balancer_set_more_tries(r, count, errmsg)
@@ -146,7 +146,7 @@ end
 function _M.get_last_failure()
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local state = ngx_lua_ffi_balancer_get_last_failure(r, int_out, errmsg)
@@ -166,13 +166,13 @@ end
 function _M.set_timeouts(connect_timeout, send_timeout, read_timeout)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if not connect_timeout then
         connect_timeout = 0
     elseif type(connect_timeout) ~= "number" or connect_timeout <= 0 then
-        return error("bad connect timeout")
+        error("bad connect timeout", 2)
     else
         connect_timeout = connect_timeout * 1000
     end
@@ -180,7 +180,7 @@ function _M.set_timeouts(connect_timeout, send_timeout, read_timeout)
     if not send_timeout then
         send_timeout = 0
     elseif type(send_timeout) ~= "number" or send_timeout <= 0 then
-        return error("bad send timeout")
+        error("bad send timeout", 2)
     else
         send_timeout = send_timeout * 1000
     end
@@ -188,7 +188,7 @@ function _M.set_timeouts(connect_timeout, send_timeout, read_timeout)
     if not read_timeout then
         read_timeout = 0
     elseif type(read_timeout) ~= "number" or read_timeout <= 0 then
-        return error("bad read timeout")
+        error("bad read timeout", 2)
     else
         read_timeout = read_timeout * 1000
     end

--- a/lib/ngx/ocsp.lua
+++ b/lib/ngx/ocsp.lua
@@ -125,7 +125,7 @@ end
 function _M.set_ocsp_status_resp(ocsp_resp)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_ssl_set_ocsp_status_resp(r, ocsp_resp,

--- a/lib/ngx/semaphore.lua
+++ b/lib/ngx/semaphore.lua
@@ -59,7 +59,7 @@ local mt = { __index = _M }
 function _M.new(n)
     n = tonumber(n) or 0
     if n < 0 then
-        return error("no negative number")
+        error("no negative number", 2)
     end
 
     local ret = C.ngx_http_lua_ffi_sema_new(psem, n, errmsg)
@@ -77,17 +77,17 @@ end
 
 function _M.wait(self, seconds)
     if type(self) ~= "table" or type(self.sem) ~= "cdata" then
-        return error("not a semaphore instance")
+        error("not a semaphore instance", 2)
     end
 
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local milliseconds = tonumber(seconds) * 1000
     if milliseconds < 0 then
-        return error("no negative number")
+        error("no negative number", 2)
     end
 
     local cdata_sem = self.sem
@@ -123,14 +123,14 @@ end
 
 function _M.post(self, n)
     if type(self) ~= "table" or type(self.sem) ~= "cdata" then
-        return error("not a semaphore instance")
+        error("not a semaphore instance", 2)
     end
 
     local cdata_sem = self.sem
 
     local num = n and tonumber(n) or 1
     if num < 1 then
-        return error("no negative number")
+        error("positive number required", 2)
     end
 
     -- always return NGX_OK
@@ -142,7 +142,7 @@ end
 
 function _M.count(self)
     if type(self) ~= "table" or type(self.sem) ~= "cdata" then
-        return error("not a semaphore instance")
+        error("not a semaphore instance", 2)
     end
 
     return C.ngx_http_lua_ffi_sema_count(self.sem)

--- a/lib/ngx/ssl.lua
+++ b/lib/ngx/ssl.lua
@@ -75,7 +75,7 @@ local intp = ffi.new("int[1]")
 function _M.clear_certs()
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_ssl_clear_certs(r, errmsg)
@@ -90,7 +90,7 @@ end
 function _M.set_der_cert(data)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_ssl_set_der_certificate(r, data, #data,
@@ -106,7 +106,7 @@ end
 function _M.set_der_priv_key(data)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_ssl_set_der_private_key(r, data, #data,
@@ -129,7 +129,7 @@ local addr_types = {
 function _M.raw_server_addr()
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local sizep = get_size_ptr()
@@ -151,7 +151,7 @@ end
 function _M.server_name()
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local sizep = get_size_ptr()
@@ -172,7 +172,7 @@ end
 function _M.raw_client_addr()
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local sizep = get_size_ptr()
@@ -219,7 +219,7 @@ local function get_tls1_version()
 
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local ver = C.ngx_http_lua_ffi_ssl_get_tls1_version(r, errmsg)
@@ -260,7 +260,7 @@ end
 function _M.set_cert(cert)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_set_cert(r, cert, errmsg)
@@ -275,7 +275,7 @@ end
 function _M.set_priv_key(priv_key)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_set_priv_key(r, priv_key, errmsg)

--- a/lib/ngx/ssl/session.lua
+++ b/lib/ngx/ssl/session.lua
@@ -40,7 +40,7 @@ local _M = { version = base.version }
 function _M.get_serialized_session()
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local len = C.ngx_http_lua_ffi_ssl_get_serialized_session_size(r, errmsg)
@@ -68,7 +68,7 @@ end
 function _M.get_session_id()
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local len = C.ngx_http_lua_ffi_ssl_get_session_id_size(r, errmsg)
@@ -93,7 +93,7 @@ end
 function _M.set_serialized_session(sess)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_ssl_set_serialized_session(r, sess, #sess,

--- a/lib/resty/core/base.lua
+++ b/lib/resty/core/base.lua
@@ -150,7 +150,7 @@ end
 
 
 if not ngx then
-    return error("no existing ngx. table found")
+    error("no existing ngx. table found")
 end
 
 

--- a/lib/resty/core/base64.lua
+++ b/lib/resty/core/base64.lua
@@ -47,7 +47,8 @@ ngx.encode_base64 = function (s, no_padding)
 
     if no_padding then
         if no_padding ~= true then
-            error("boolean argument only")
+            local typ = type(no_padding)
+            error("bad no_padding: boolean expected, got " .. typ, 2)
         end
 
         no_padding_bool = true
@@ -70,7 +71,7 @@ end
 
 ngx.decode_base64 = function (s)
     if type(s) ~= 'string' then
-        error("string argument only")
+        error("string argument only", 2)
     end
     local slen = #s
     local dlen = base64_decoded_length(slen)

--- a/lib/resty/core/base64.lua
+++ b/lib/resty/core/base64.lua
@@ -47,7 +47,7 @@ ngx.encode_base64 = function (s, no_padding)
 
     if no_padding then
         if no_padding ~= true then
-            return error("boolean argument only")
+            error("boolean argument only")
         end
 
         no_padding_bool = true
@@ -70,7 +70,7 @@ end
 
 ngx.decode_base64 = function (s)
     if type(s) ~= 'string' then
-        return error("string argument only")
+        error("string argument only")
     end
     local slen = #s
     local dlen = base64_decoded_length(slen)

--- a/lib/resty/core/ctx.lua
+++ b/lib/resty/core/ctx.lua
@@ -34,12 +34,12 @@ local function get_ctx_table()
     local r = getfenv(0).__ngx_req
 
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local ctx_ref = C.ngx_http_lua_ffi_get_ctx_ref(r)
     if ctx_ref == FFI_NO_REQ_CTX then
-        return error("no request ctx found")
+        error("no request ctx found")
     end
 
     local ctxs = registry.ngx_lua_ctx_tables
@@ -60,12 +60,12 @@ local function set_ctx_table(ctx)
     local r = getfenv(0).__ngx_req
 
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local ctx_ref = C.ngx_http_lua_ffi_get_ctx_ref(r)
     if ctx_ref == FFI_NO_REQ_CTX then
-        return error("no request ctx found")
+        error("no request ctx found")
     end
 
     local ctxs = registry.ngx_lua_ctx_tables

--- a/lib/resty/core/exit.lua
+++ b/lib/resty/core/exit.lua
@@ -28,7 +28,7 @@ ngx.exit = function (rc)
     local errlen = get_size_ptr()
     local r = getfenv(0).__ngx_req
     if r == nil then
-        return error("no request found")
+        error("no request found")
     end
     errlen[0] = ERR_BUF_SIZE
     rc = C.ngx_http_lua_ffi_exit(r, rc, err, errlen)
@@ -39,7 +39,7 @@ ngx.exit = function (rc)
     if rc == FFI_DONE then
         return
     end
-    return error(ffi_string(err, errlen[0]))
+    error(ffi_string(err, errlen[0]))
 end
 
 

--- a/lib/resty/core/hash.lua
+++ b/lib/resty/core/hash.lua
@@ -69,7 +69,7 @@ ngx.sha1_bin = function (s)
     end
     local ok = C.ngx_http_lua_ffi_sha1_bin(s, #s, sha_buf)
     if ok == 0 then
-        return error("SHA-1 support missing in Nginx")
+        error("SHA-1 support missing in Nginx")
     end
     return ffi_string(sha_buf, SHA_DIGEST_LEN)
 end

--- a/lib/resty/core/misc.lua
+++ b/lib/resty/core/misc.lua
@@ -72,13 +72,13 @@ local function get_status()
     local r = getfenv(0).__ngx_req
 
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_get_resp_status(r)
 
     if rc == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     return rc
@@ -90,7 +90,7 @@ local function set_status(status)
     local r = getfenv(0).__ngx_req
 
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if type(status) ~= 'number' then
@@ -100,7 +100,7 @@ local function set_status(status)
     local rc = C.ngx_http_lua_ffi_set_resp_status(r, status)
 
     if rc == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     return
@@ -114,13 +114,13 @@ local function is_subreq()
     local r = getfenv(0).__ngx_req
 
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_is_subrequest(r)
 
     if rc == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     return rc == 1
@@ -134,17 +134,17 @@ local function headers_sent()
     local r = getfenv(0).__ngx_req
 
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local rc = C.ngx_http_lua_ffi_headers_sent(r)
 
     if rc == FFI_NO_REQ_CTX then
-        return error("no request ctx found")
+        error("no request ctx found")
     end
 
     if rc == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     return rc == 1

--- a/lib/resty/core/regex.lua
+++ b/lib/resty/core/regex.lua
@@ -222,8 +222,7 @@ local function parse_regex_opts(opts)
             pcre_opts = bor(pcre_opts, PCRE_JAVASCRIPT_COMPAT)
 
         else
-            return error(fmt('unknown flag "%s" (flags "%s")',
-                             sub(opts, i, i), opts))
+            error(fmt('unknown flag "%s" (flags "%s")', sub(opts, i, i), opts))
         end
     end
 

--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -257,7 +257,7 @@ function ngx.req.set_method(method)
     end
 
     if type(method) ~= "number" then
-        error("bad method number")
+        error("bad method number", 2)
     end
 
     local rc = C.ngx_http_lua_ffi_req_set_method(r, method)

--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -73,7 +73,7 @@ local req_headers_mt = {
 function ngx.req.get_headers(max_headers, raw)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if not max_headers then
@@ -88,7 +88,7 @@ function ngx.req.get_headers(max_headers, raw)
 
     local n = C.ngx_http_lua_ffi_req_get_headers_count(r, max_headers)
     if n == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     if n == 0 then
@@ -135,7 +135,7 @@ end
 function ngx.req.get_uri_args(max_args)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if not max_args then
@@ -144,7 +144,7 @@ function ngx.req.get_uri_args(max_args)
 
     local n = C.ngx_http_lua_ffi_req_get_uri_args_count(r, max_args)
     if n == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     if n == 0 then
@@ -192,7 +192,7 @@ end
 function ngx.req.start_time()
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     return tonumber(C.ngx_http_lua_ffi_req_start_time(r))
@@ -221,13 +221,13 @@ do
     function ngx.req.get_method()
         local r = getfenv(0).__ngx_req
         if not r then
-            return error("no request found")
+            error("no request found")
         end
 
         do
             local id = C.ngx_http_lua_ffi_req_get_method(r)
             if id == FFI_BAD_CONTEXT then
-                return error("API disabled in the current context")
+                error("API disabled in the current context")
             end
 
             local method = methods[id]
@@ -253,11 +253,11 @@ end  -- do
 function ngx.req.set_method(method)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if type(method) ~= "number" then
-        return error("bad method number")
+        error("bad method number")
     end
 
     local rc = C.ngx_http_lua_ffi_req_set_method(r, method)
@@ -266,14 +266,14 @@ function ngx.req.set_method(method)
     end
 
     if rc == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     if rc == FFI_DECLINED then
-        return error("unsupported HTTP method: " .. method)
+        error("unsupported HTTP method: " .. method)
     end
 
-    return error("unknown error: " .. rc)
+    error("unknown error: " .. rc)
 end
 
 
@@ -287,7 +287,7 @@ do
 
         local r = getfenv(0).__ngx_req
         if not r then
-            return error("no request found")
+            error("no request found")
         end
 
         if type(name) ~= "string" then
@@ -313,10 +313,10 @@ do
         end
 
         if rc == FFI_BAD_CONTEXT then
-            return error("API disabled in the current context")
+            error("API disabled in the current context")
         end
 
-        return error("error")
+        error("error")
     end
 end  -- do
 
@@ -324,7 +324,7 @@ end  -- do
 function ngx.req.clear_header(name)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if type(name) ~= "string" then
@@ -339,10 +339,10 @@ function ngx.req.clear_header(name)
     end
 
     if rc == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
-    return error("error")
+    error("error")
 end
 
 

--- a/lib/resty/core/response.lua
+++ b/lib/resty/core/response.lua
@@ -43,7 +43,7 @@ ffi.cdef[[
 local function set_resp_header(tb, key, value)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if type(key) ~= "string" then
@@ -95,22 +95,22 @@ local function set_resp_header(tb, key, value)
     end
 
     if rc == FFI_NO_REQ_CTX then
-        return error("no request ctx found")
+        error("no request ctx found")
     end
 
     if rc == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     -- rc == FFI_ERROR
-    return error(ffi_str(errmsg[0]))
+    error(ffi_str(errmsg[0]))
 end
 
 
 local function get_resp_header(tb, key)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if type(key) ~= "string" then
@@ -127,7 +127,7 @@ local function get_resp_header(tb, key)
     -- print("retval: ", n)
 
     if n == FFI_BAD_CONTEXT then
-        return error("API disabled in the current context")
+        error("API disabled in the current context")
     end
 
     if n == 0 then
@@ -149,7 +149,7 @@ local function get_resp_header(tb, key)
     end
 
     -- n == FFI_ERROR
-    return error("no memory")
+    error("no memory")
 end
 
 

--- a/lib/resty/core/shdict.lua
+++ b/lib/resty/core/shdict.lua
@@ -72,12 +72,12 @@ local errmsg = base.get_errmsg_ptr()
 
 local function check_zone(zone)
     if not zone or type(zone) ~= "table" then
-        error("bad \"zone\" argument")
+        error("bad \"zone\" argument", 2)
     end
 
     zone = zone[1]
     if type(zone) ~= "userdata" then
-        error("bad \"zone\" argument")
+        error("bad \"zone\" argument", 2)
     end
 
     return zone
@@ -90,7 +90,7 @@ local function shdict_store(zone, op, key, value, exptime, flags)
     if not exptime then
         exptime = 0
     elseif exptime < 0 then
-        error('bad "exptime" argument')
+        error('bad "exptime" argument', 2)
     end
 
     if not flags then
@@ -367,7 +367,7 @@ local function shdict_incr(zone, key, value, init, init_ttl)
             init = tonumber(init)
 
             if not init then
-                error("bad init arg: number expected, got " .. typ)
+                error("bad init arg: number expected, got " .. typ, 2)
             end
         end
     end

--- a/lib/resty/core/shdict.lua
+++ b/lib/resty/core/shdict.lua
@@ -72,12 +72,12 @@ local errmsg = base.get_errmsg_ptr()
 
 local function check_zone(zone)
     if not zone or type(zone) ~= "table" then
-        return error("bad \"zone\" argument")
+        error("bad \"zone\" argument")
     end
 
     zone = zone[1]
     if type(zone) ~= "userdata" then
-        return error("bad \"zone\" argument")
+        error("bad \"zone\" argument")
     end
 
     return zone
@@ -90,7 +90,7 @@ local function shdict_store(zone, op, key, value, exptime, flags)
     if not exptime then
         exptime = 0
     elseif exptime < 0 then
-        return error('bad "exptime" argument')
+        error('bad "exptime" argument')
     end
 
     if not flags then
@@ -222,7 +222,7 @@ local function shdict_get(zone, key)
             return nil, ffi_str(errmsg[0])
         end
 
-        return error("failed to get the key")
+        error("failed to get the key")
     end
 
     local typ = value_type[0]
@@ -252,7 +252,7 @@ local function shdict_get(zone, key)
         val = (tonumber(buf[0]) ~= 0)
 
     else
-        return error("unknown value type: " .. typ)
+        error("unknown value type: " .. typ)
     end
 
     if flags ~= 0 then
@@ -297,7 +297,7 @@ local function shdict_get_stale(zone, key)
             return nil, ffi_str(errmsg[0])
         end
 
-        return error("failed to get the key")
+        error("failed to get the key")
     end
 
     local typ = value_type[0]
@@ -326,7 +326,7 @@ local function shdict_get_stale(zone, key)
         val = (tonumber(buf[0]) ~= 0)
 
     else
-        return error("unknown value type: " .. typ)
+        error("unknown value type: " .. typ)
     end
 
     if flags ~= 0 then
@@ -367,7 +367,7 @@ local function shdict_incr(zone, key, value, init, init_ttl)
             init = tonumber(init)
 
             if not init then
-                return error("bad init arg: number expected, got " .. typ)
+                error("bad init arg: number expected, got " .. typ)
             end
         end
     end

--- a/lib/resty/core/var.lua
+++ b/lib/resty/core/var.lua
@@ -49,7 +49,7 @@ local function var_get(self, name)
 
     else
         if type(name) ~= "string" then
-            error("bad variable name")
+            error("bad variable name", 2)
         end
 
         local name_len = #name
@@ -82,7 +82,7 @@ local function var_set(self, name, value)
     end
 
     if type(name) ~= "string" then
-        error("bad variable name")
+        error("bad variable name", 2)
     end
     local name_len = #name
 

--- a/lib/resty/core/var.lua
+++ b/lib/resty/core/var.lua
@@ -38,7 +38,7 @@ local errmsg = base.get_errmsg_ptr()
 local function var_get(self, name)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     local value_len = get_size_ptr()
@@ -49,7 +49,7 @@ local function var_get(self, name)
 
     else
         if type(name) ~= "string" then
-            return error("bad variable name")
+            error("bad variable name")
         end
 
         local name_len = #name
@@ -70,7 +70,7 @@ local function var_get(self, name)
     end
 
     if rc == -1 then  -- NGX_ERROR
-        return error(ffi_str(errmsg[0]))
+        error(ffi_str(errmsg[0]))
     end
 end
 
@@ -78,11 +78,11 @@ end
 local function var_set(self, name, value)
     local r = getfenv(0).__ngx_req
     if not r then
-        return error("no request found")
+        error("no request found")
     end
 
     if type(name) ~= "string" then
-        return error("bad variable name")
+        error("bad variable name")
     end
     local name_len = #name
 
@@ -111,7 +111,7 @@ local function var_set(self, name, value)
     end
 
     if rc == -1 then  -- NGX_ERROR
-        return error(ffi_str(errbuf, errlen[0]))
+        error(ffi_str(errbuf, errlen[0]))
     end
 end
 

--- a/t/var.t
+++ b/t/var.t
@@ -233,9 +233,9 @@ qr/\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):3 loop\]/
     }
 --- request
 GET /test
---- response_body
-content_by_lua(nginx.conf:62):2: variable "foo" not found for writing; maybe it is a built-in variable that is not changeable or you forgot to use "set $foo '';" in the config file to define it first
-content_by_lua(nginx.conf:62):3: variable "server_port" not changeable
+--- response_body_like
+.+/var\.lua:\d+: variable "foo" not found for writing; maybe it is a built-in variable that is not changeable or you forgot to use "set \$foo '';" in the config file to define it first
+.+/var\.lua:\d+: variable "server_port" not changeable
 --- no_error_log
 [error]
 [alert]


### PR DESCRIPTION
For #108 
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
