### PR TITLE
improvement: avoided redundant copy in ngx.req.get_method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone https://github.com/spacewander/lua-nginx-module.git -b avoid_mem_copy_in_get_method_name ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git


### PR DESCRIPTION
This is the sister pr of https://github.com/openresty/lua-nginx-module/pull/1252.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
