### PR TITLE
remove my_require

### DIFF
--- a/lib/resty/core/base.lua
+++ b/lib/resty/core/base.lua
@@ -60,24 +60,6 @@ if not ok then
 end
 
 
--- XXX for now LuaJIT 2.1 cannot compile require()
--- so we make the fast code path Lua only in our own
--- wrapper so that most of the require() calls in hot
--- Lua code paths can be JIT compiled.
-do
-    local orig_require = require
-    local pkg_loaded = package.loaded
-    local function my_require(name)
-        local mod = pkg_loaded[name]
-        if mod then
-            return mod
-        end
-        return orig_require(name)
-    end
-    getfenv(0).require = my_require
-end
-
-
 if not pcall(ffi.typeof, "ngx_str_t") then
     ffi.cdef[[
         typedef struct {


### PR DESCRIPTION
Because the function `require()` is not yet implemented by LuaJit. So, I guess the implemented function `my_require()` aims to avoid loading the package that has already been loaded, right?

However, `require()` function itself will check whether the package is already loaded. So is there any need to implement `my_require()` function? If yes, could you explain the reason beneath the surface.

Thank you!

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
