### PR TITLE
change param expire to int64

### DIFF
--- a/lib/resty/core/shdict.lua
+++ b/lib/resty/core/shdict.lua
@@ -34,16 +34,16 @@ ffi.cdef[[
     int ngx_http_lua_ffi_shdict_store(void *zone, int op,
         const unsigned char *key, size_t key_len, int value_type,
         const unsigned char *str_value_buf, size_t str_value_len,
-        double num_value, int exptime, int user_flags, char **errmsg,
+        double num_value, uint64_t exptime, int user_flags, char **errmsg,
         int *forcible);
 
     int ngx_http_lua_ffi_shdict_flush_all(void *zone);
 
-    int ngx_http_lua_ffi_shdict_get_ttl(void *zone,
+    uint64_t ngx_http_lua_ffi_shdict_get_ttl(void *zone,
         const unsigned char *key, size_t key_len);
 
     int ngx_http_lua_ffi_shdict_set_expire(void *zone,
-        const unsigned char *key, size_t key_len, int exptime);
+        const unsigned char *key, size_t key_len, uint64_t exptime);
 
     size_t ngx_http_lua_ffi_shdict_capacity(void *zone);
 ]]


### PR DESCRIPTION
when use the new shdict api in resty/core，the expire may not process correctly，it use type int to story expire but not uint64 as before。when the expire is large，for example 10000000，it goes wrong。I also change the function in the c file
