### PR TITLE
tests: used `\d+` to match the trace id.

### DIFF
--- a/t/process-type-cache.t
+++ b/t/process-type-cache.t
@@ -80,11 +80,11 @@ type: worker
 qr/\[TRACE   \d+ init_worker_by_lua:\d loop\]|\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):\d loop\]|process type: \w+/
 --- grep_error_log_out eval
 [
-qr/\[TRACE   \d init_worker_by_lua:5 loop\]
-\[TRACE   \d content_by_lua\(nginx.conf:78\):5 loop\]
+qr/\[TRACE   \d+ init_worker_by_lua:5 loop\]
+\[TRACE   \d+ content_by_lua\(nginx.conf:78\):5 loop\]
 /,
-qr/\[TRACE   \d init_worker_by_lua:5 loop\]
-\[TRACE   \d content_by_lua\(nginx.conf:78\):5 loop\]
+qr/\[TRACE   \d+ init_worker_by_lua:5 loop\]
+\[TRACE   \d+ content_by_lua\(nginx.conf:78\):5 loop\]
 /
 ]
 --- no_error_log

--- a/t/process-type-master.t
+++ b/t/process-type-master.t
@@ -75,12 +75,12 @@ process type: worker
 qr/\[TRACE   \d+ init_worker_by_lua:4 loop\]|\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]|init_worker_by_lua:\d: process type: \w+/
 --- grep_error_log_out eval
 [
-qr/\[TRACE   1 init_worker_by_lua:4 loop\]
-\[TRACE   2 content_by_lua\(nginx.conf:73\):4 loop\]
+qr/\[TRACE   \d+ init_worker_by_lua:4 loop\]
+\[TRACE   \d+ content_by_lua\(nginx.conf:73\):4 loop\]
 init_worker_by_lua:8: process type: worker
 /,
-qr/\[TRACE   1 init_worker_by_lua:4 loop\]
-\[TRACE   2 content_by_lua\(nginx.conf:73\):4 loop\]
+qr/\[TRACE   \d+ init_worker_by_lua:4 loop\]
+\[TRACE   \d+ content_by_lua\(nginx.conf:73\):4 loop\]
 init_worker_by_lua:8: process type: worker
 /
 ]

--- a/t/process-type-privileged-agent.t
+++ b/t/process-type-privileged-agent.t
@@ -83,14 +83,14 @@ type: worker
 qr/\[TRACE   \d+ init_worker_by_lua:\d+ loop\]|\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):\d+ loop\]|init_worker_by_lua:\d+: process type: \w+/
 --- grep_error_log_out eval
 [
-qr/\[TRACE   \d init_worker_by_lua:5 loop\]
-(?:\[TRACE   \d init_worker_by_lua:5 loop\]
-)?\[TRACE   \d content_by_lua\(nginx.conf:81\):5 loop\]
+qr/\[TRACE   \d+ init_worker_by_lua:5 loop\]
+(?:\[TRACE   \d+ init_worker_by_lua:5 loop\]
+)?\[TRACE   \d+ content_by_lua\(nginx.conf:81\):5 loop\]
 init_worker_by_lua:10: process type: privileged
 /,
-qr/\[TRACE   \d init_worker_by_lua:5 loop\]
-(?:\[TRACE   \d init_worker_by_lua:5 loop\]
-)?\[TRACE   \d content_by_lua\(nginx.conf:81\):5 loop\]
+qr/\[TRACE   \d+ init_worker_by_lua:5 loop\]
+(?:\[TRACE   \d+ init_worker_by_lua:5 loop\]
+)?\[TRACE   \d+ content_by_lua\(nginx.conf:81\):5 loop\]
 init_worker_by_lua:10: process type: privileged
 /
 ]


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
