### PR TITLE
change: narrowed the ngx_lua_version requirement.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,8 +96,8 @@ of this library in the particular OpenResty release you are using. Otherwise you
 into serious comaptibility issues.
 
 * LuaJIT 2.1 (for now, it is the v2.1 git branch in the official luajit-2.0 git repository: http://luajit.org/download.html )
-* [ngx_http_lua_module](https://github.com/openresty/lua-nginx-module) v0.10.13 or later.
-* [ngx_stream_lua_module](https://github.com/openresty/lua-nginx-module) v0.0.5 or later.
+* [ngx_http_lua_module](https://github.com/openresty/lua-nginx-module) v0.10.13.
+* [ngx_stream_lua_module](https://github.com/openresty/lua-nginx-module) v0.0.5.
 * [lua-resty-lrucache](https://github.com/openresty/lua-resty-lrucache)
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/core/base.lua
+++ b/lib/resty/core/base.lua
@@ -18,22 +18,22 @@ local FREE_LIST_REF = 0
 if subsystem == 'http' then
     if not ngx.config
        or not ngx.config.ngx_lua_version
-       or ngx.config.ngx_lua_version < 10013
+       or ngx.config.ngx_lua_version ~= 10013
     then
-        error("ngx_http_lua_module 0.10.13+ required")
+        error("ngx_http_lua_module 0.10.13 required")
     end
 
 elseif subsystem == 'stream' then
     if not ngx.config
        or not ngx.config.ngx_lua_version
-       or ngx.config.ngx_lua_version < 5
+       or ngx.config.ngx_lua_version ~= 5
     then
-        error("ngx_stream_lua_module 0.0.5+ required")
+        error("ngx_stream_lua_module 0.0.5 required")
     end
 
 else
-    error("ngx_http_lua_module 0.10.13+ or "
-          .. "ngx_stream_lua_module 0.0.5+ required")
+    error("ngx_http_lua_module 0.10.13 or "
+          .. "ngx_stream_lua_module 0.0.5 required")
 end
 
 


### PR DESCRIPTION
If we change "char **errmsg" to "unsigned char *errbuf" in the FFI C
function, then the old lua-resty-core won't work anymore. Howerver, we only check
if the lua-nginx-module is older than required, so in this case an old
lua-resty-core could pass the verification.

As we don't ensure the backward compatibility of FFI C functions,
it is better to specify the ngx_lua_version as a number instead of a range.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
