### PR TITLE
bugfix: error out when a shdict key is not a string

### DIFF
--- a/lib/resty/core/shdict.lua
+++ b/lib/resty/core/shdict.lua
@@ -11,7 +11,6 @@ local get_string_buf = base.get_string_buf
 local get_string_buf_size = base.get_string_buf_size
 local get_size_ptr = base.get_size_ptr
 local tonumber = tonumber
-local tostring = tostring
 local next = next
 local type = type
 local error = error
@@ -102,7 +101,7 @@ local function shdict_store(zone, op, key, value, exptime, flags)
     end
 
     if type(key) ~= "string" then
-        key = tostring(key)
+        error("bad key (string expected, got " .. type(key) .. ")")
     end
 
     local key_len = #key
@@ -196,7 +195,7 @@ local function shdict_get(zone, key)
     end
 
     if type(key) ~= "string" then
-        key = tostring(key)
+        error("bad key (string expected, got " .. type(key) .. ")")
     end
 
     local key_len = #key
@@ -271,7 +270,7 @@ local function shdict_get_stale(zone, key)
     end
 
     if type(key) ~= "string" then
-        key = tostring(key)
+        error("bad key (string expected, got " .. type(key) .. ")")
     end
 
     local key_len = #key
@@ -345,7 +344,7 @@ local function shdict_incr(zone, key, value, init, init_ttl)
     end
 
     if type(key) ~= "string" then
-        key = tostring(key)
+        error("bad key (string expected, got " .. type(key) .. ")")
     end
 
     local key_len = #key
@@ -425,7 +424,7 @@ local function shdict_ttl(zone, key)
     end
 
     if type(key) ~= "string" then
-        key = tostring(key)
+        error("bad key (string expected, got " .. type(key) .. ")")
     end
 
     local key_len = #key
@@ -463,7 +462,7 @@ local function shdict_expire(zone, key, exptime)
     end
 
     if type(key) ~= "string" then
-        key = tostring(key)
+        error("bad key (string expected, got " .. type(key) .. ")")
     end
 
     local key_len = #key

--- a/lib/resty/core/shdict.lua
+++ b/lib/resty/core/shdict.lua
@@ -101,7 +101,9 @@ local function shdict_store(zone, op, key, value, exptime, flags)
     end
 
     if type(key) ~= "string" then
-        error("bad key (string expected, got " .. type(key) .. ")")
+        -- technically this function is not called directly, but due to the
+        -- tail return semantics, the stack level 2 is correct here
+        error("bad key (string expected, got " .. type(key) .. ")", 2)
     end
 
     local key_len = #key
@@ -195,7 +197,7 @@ local function shdict_get(zone, key)
     end
 
     if type(key) ~= "string" then
-        error("bad key (string expected, got " .. type(key) .. ")")
+        error("bad key (string expected, got " .. type(key) .. ")", 2)
     end
 
     local key_len = #key
@@ -270,7 +272,7 @@ local function shdict_get_stale(zone, key)
     end
 
     if type(key) ~= "string" then
-        error("bad key (string expected, got " .. type(key) .. ")")
+        error("bad key (string expected, got " .. type(key) .. ")", 2)
     end
 
     local key_len = #key
@@ -344,7 +346,7 @@ local function shdict_incr(zone, key, value, init, init_ttl)
     end
 
     if type(key) ~= "string" then
-        error("bad key (string expected, got " .. type(key) .. ")")
+        error("bad key (string expected, got " .. type(key) .. ")", 2)
     end
 
     local key_len = #key
@@ -424,7 +426,7 @@ local function shdict_ttl(zone, key)
     end
 
     if type(key) ~= "string" then
-        error("bad key (string expected, got " .. type(key) .. ")")
+        error("bad key (string expected, got " .. type(key) .. ")", 2)
     end
 
     local key_len = #key
@@ -462,7 +464,7 @@ local function shdict_expire(zone, key, exptime)
     end
 
     if type(key) ~= "string" then
-        error("bad key (string expected, got " .. type(key) .. ")")
+        error("bad key (string expected, got " .. type(key) .. ")", 2)
     end
 
     local key_len = #key

--- a/t/shdict.t
+++ b/t/shdict.t
@@ -1636,3 +1636,63 @@ ttl: 2147483648
 [error]
 [alert]
 [crit]
+
+
+
+=== TEST 50: trying to use a non-string key is an error
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local dogs = ngx.shared.dogs
+            local ok, err
+            dogs:flush_all()
+
+            ok, err = pcall(dogs.set, dogs, {}, '')
+            ngx.say('set ', ok, ' ', err)
+
+            ok, err = pcall(dogs.safe_set, dogs, {}, '')
+            ngx.say('safe_set ', ok, ' ', err)
+
+            ok, err = pcall(dogs.get, dogs, function() end)
+            ngx.say('get ', ok, ' ', err)
+
+            ok, err = pcall(dogs.get_stale, dogs, function() end)
+            ngx.say('get_stale ', ok, ' ', err)
+
+            ok, err = pcall(dogs.add, dogs, 0, '')
+            ngx.say('add ', ok, ' ', err)
+
+            ok, err = pcall(dogs.safe_add, dogs, 0, '')
+            ngx.say('safe_add ', ok, ' ', err)
+
+            ok, err = pcall(dogs.replace, dogs, {}, '')
+            ngx.say('replace ', ok, ' ', err)
+
+            ok, err = pcall(dogs.delete, dogs, {})
+            ngx.say('delete ', ok, ' ', err)
+
+            ok, err = pcall(dogs.incr, dogs, true, 0)
+            ngx.say('incr ', ok, ' ', err)
+
+            ok, err = pcall(dogs.ttl, dogs, {})
+            ngx.say('ttl ', ok, ' ', err)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+set false .*: bad key \(string expected, got table\)
+safe_set false .*: bad key \(string expected, got table\)
+get false .*: bad key \(string expected, got function\)
+get_stale false .*: bad key \(string expected, got function\)
+add false .*: bad key \(string expected, got number\)
+safe_add false .*: bad key \(string expected, got number\)
+replace false .*: bad key \(string expected, got table\)
+delete false .*: bad key \(string expected, got table\)
+incr false .*: bad key \(string expected, got boolean\)
+ttl false .*: bad key \(string expected, got table\)
+--- no_error_log
+[error]
+[alert]
+[crit]

--- a/t/shdict.t
+++ b/t/shdict.t
@@ -1648,50 +1648,50 @@ ttl: 2147483648
             local ok, err
             dogs:flush_all()
 
-            ok, err = pcall(dogs.set, dogs, {}, '')
+            ok, err = pcall(function() dogs:set({}, '') end)
             ngx.say('set ', ok, ' ', err)
 
-            ok, err = pcall(dogs.safe_set, dogs, {}, '')
+            ok, err = pcall(function() dogs:safe_set({}, '') end)
             ngx.say('safe_set ', ok, ' ', err)
 
-            ok, err = pcall(dogs.get, dogs, function() end)
+            ok, err = pcall(function() dogs:get(function() end) end)
             ngx.say('get ', ok, ' ', err)
 
-            ok, err = pcall(dogs.get_stale, dogs, function() end)
+            ok, err = pcall(function() dogs:get_stale(function() end) end)
             ngx.say('get_stale ', ok, ' ', err)
 
-            ok, err = pcall(dogs.add, dogs, 0, '')
+            ok, err = pcall(function() dogs:add(0, '') end)
             ngx.say('add ', ok, ' ', err)
 
-            ok, err = pcall(dogs.safe_add, dogs, 0, '')
+            ok, err = pcall(function() dogs:safe_add(0, '') end)
             ngx.say('safe_add ', ok, ' ', err)
 
-            ok, err = pcall(dogs.replace, dogs, {}, '')
+            ok, err = pcall(function() dogs:replace({}, '') end)
             ngx.say('replace ', ok, ' ', err)
 
-            ok, err = pcall(dogs.delete, dogs, {})
+            ok, err = pcall(function() dogs:delete({}) end)
             ngx.say('delete ', ok, ' ', err)
 
-            ok, err = pcall(dogs.incr, dogs, true, 0)
+            ok, err = pcall(function() dogs:incr(true, 0) end)
             ngx.say('incr ', ok, ' ', err)
 
-            ok, err = pcall(dogs.ttl, dogs, {})
+            ok, err = pcall(function() dogs:ttl({}) end)
             ngx.say('ttl ', ok, ' ', err)
         }
     }
 --- request
 GET /t
 --- response_body_like
-set false .*: bad key \(string expected, got table\)
-safe_set false .*: bad key \(string expected, got table\)
-get false .*: bad key \(string expected, got function\)
-get_stale false .*: bad key \(string expected, got function\)
-add false .*: bad key \(string expected, got number\)
-safe_add false .*: bad key \(string expected, got number\)
-replace false .*: bad key \(string expected, got table\)
-delete false .*: bad key \(string expected, got table\)
-incr false .*: bad key \(string expected, got boolean\)
-ttl false .*: bad key \(string expected, got table\)
+set false content_by_lua.*: bad key \(string expected, got table\)
+safe_set false content_by_lua.*: bad key \(string expected, got table\)
+get false content_by_lua.*: bad key \(string expected, got function\)
+get_stale false content_by_lua.*: bad key \(string expected, got function\)
+add false content_by_lua.*: bad key \(string expected, got number\)
+safe_add false content_by_lua.*: bad key \(string expected, got number\)
+replace false content_by_lua.*: bad key \(string expected, got table\)
+delete false content_by_lua.*: bad key \(string expected, got table\)
+incr false content_by_lua.*: bad key \(string expected, got boolean\)
+ttl false content_by_lua.*: bad key \(string expected, got table\)
 --- no_error_log
 [error]
 [alert]


### PR DESCRIPTION
This is to stick with the behavior of the regular C API that uses
`luaL_checklstring` for keys, that throws a runtime error when a non-string
key is passed. For some reason, a soft `nil, error` is returned
specifically for `nil` keys, to that bihavor is kept here too.

Note: the error message between the C and the FFI representation is slightly different (`bad argument #1 to 'set' (string expected, got table)` for the C variant, `./resty/core/shdict.lua:105: bad key (string expected, got table)` for the FFI one) but I think it is quite minor.

FTR: it led to a very hard to debug issue where we were wrongly using a table as key in some cases. The string representation of it (e.g. `table: 0x400b63e0`) was sometime triggering collisions where a new table happened to be allocated at the same address as a previous one.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
