### PR TITLE
tests: upgraded openssl version to 1.1.0h.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     - OLD_OPENSSL_VER=0.9.8o
   matrix:
     - NGINX_VERSION=1.13.6 OPENSSL_VER=1.0.2n OPENSSL_PATCH_VER=1.0.2h
-    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.1.0g OPENSSL_PATCH_VER=1.1.0d
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.1.0h OPENSSL_PATCH_VER=1.1.0d
 
 before_install:
   - sudo luarocks install luacheck $LUACHECK_VER


### PR DESCRIPTION
Since the openresty-openssl package is using openssl 1.1.0h now, let's upgrade the OpenSSL version to 1.1.0h in the CI.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
