### PR TITLE
feature: make os.getenv see env directives in init_by_lua.

### DIFF
--- a/lib/resty/core.lua
+++ b/lib/resty/core.lua
@@ -6,6 +6,7 @@ local subsystem = ngx.config.subsystem
 require "resty.core.regex"
 require "resty.core.shdict"
 require "resty.core.time"
+require "resty.core.misc"
 
 
 if subsystem == 'http' then
@@ -16,7 +17,6 @@ if subsystem == 'http' then
     require "resty.core.exit"
     require "resty.core.var"
     require "resty.core.ctx"
-    require "resty.core.misc"
     require "resty.core.request"
     require "resty.core.response"
     require "resty.core.time"

--- a/lib/resty/core/misc.lua
+++ b/lib/resty/core/misc.lua
@@ -3,153 +3,223 @@
 
 local base = require "resty.core.base"
 local ffi = require "ffi"
+local os = require "os"
 
 
+local FFI_OK = base.FFI_OK
 local FFI_NO_REQ_CTX = base.FFI_NO_REQ_CTX
 local FFI_BAD_CONTEXT = base.FFI_BAD_CONTEXT
+local get_string_buf = base.get_string_buf
+local get_string_buf_size = base.get_string_buf_size
+local get_size_ptr = base.get_size_ptr
 local new_tab = base.new_tab
 local C = ffi.C
+local ffi_new = ffi.new
+local ffi_str = ffi.string
 local getmetatable = getmetatable
-local ngx_magic_key_getters = new_tab(0, 4)
-local ngx_magic_key_setters = new_tab(0, 2)
 local ngx = ngx
 local get_request = base.get_request
 local type = type
 local error = error
 local tonumber = tonumber
+local subsystem = ngx.config.subsystem
 
 
-local _M = new_tab(0, 3)
+local _M
+local ngx_lua_ffi_get_conf_env
+
+
+if subsystem == 'http' then
+    _M = new_tab(0, 3)
+
+
+    local ngx_magic_key_getters = new_tab(0, 4)
+    local ngx_magic_key_setters = new_tab(0, 2)
+
+
+    local function register_getter(key, func)
+        ngx_magic_key_getters[key] = func
+    end
+    _M.register_ngx_magic_key_getter = register_getter
+
+
+    local function register_setter(key, func)
+        ngx_magic_key_setters[key] = func
+    end
+    _M.register_ngx_magic_key_setter = register_setter
+
+
+    local mt = getmetatable(ngx)
+
+
+    local old_index = mt.__index
+    mt.__index = function (tb, key)
+        local f = ngx_magic_key_getters[key]
+        if f then
+            return f()
+        end
+        return old_index(tb, key)
+    end
+
+
+    local old_newindex = mt.__newindex
+    mt.__newindex = function (tb, key, ctx)
+        local f = ngx_magic_key_setters[key]
+        if f then
+            return f(ctx)
+        end
+        return old_newindex(tb, key, ctx)
+    end
+
+
+    ffi.cdef[[
+int ngx_http_lua_ffi_get_resp_status(ngx_http_request_t *r);
+int ngx_http_lua_ffi_set_resp_status(ngx_http_request_t *r, int r);
+int ngx_http_lua_ffi_is_subrequest(ngx_http_request_t *r);
+int ngx_http_lua_ffi_headers_sent(ngx_http_request_t *r);
+int ngx_http_lua_ffi_get_conf_env(const unsigned char *name,
+    unsigned char **env_buf, size_t *name_len);
+    ]]
+
+
+    ngx_lua_ffi_get_conf_env = C.ngx_http_lua_ffi_get_conf_env
+
+
+    -- ngx.status
+
+    local function get_status()
+        local r = get_request()
+
+        if not r then
+            error("no request found")
+        end
+
+        local rc = C.ngx_http_lua_ffi_get_resp_status(r)
+
+        if rc == FFI_BAD_CONTEXT then
+            error("API disabled in the current context")
+        end
+
+        return rc
+    end
+    register_getter("status", get_status)
+
+
+    local function set_status(status)
+        local r = get_request()
+
+        if not r then
+            error("no request found")
+        end
+
+        if type(status) ~= 'number' then
+            status = tonumber(status)
+        end
+
+        local rc = C.ngx_http_lua_ffi_set_resp_status(r, status)
+
+        if rc == FFI_BAD_CONTEXT then
+            error("API disabled in the current context")
+        end
+
+        return
+    end
+    register_setter("status", set_status)
+
+
+    -- ngx.is_subrequest
+
+    local function is_subreq()
+        local r = get_request()
+
+        if not r then
+            error("no request found")
+        end
+
+        local rc = C.ngx_http_lua_ffi_is_subrequest(r)
+
+        if rc == FFI_BAD_CONTEXT then
+            error("API disabled in the current context")
+        end
+
+        return rc == 1
+    end
+    register_getter("is_subrequest", is_subreq)
+
+
+    -- ngx.headers_sent
+
+    local function headers_sent()
+        local r = get_request()
+
+        if not r then
+            error("no request found")
+        end
+
+        local rc = C.ngx_http_lua_ffi_headers_sent(r)
+
+        if rc == FFI_NO_REQ_CTX then
+            error("no request ctx found")
+        end
+
+        if rc == FFI_BAD_CONTEXT then
+            error("API disabled in the current context")
+        end
+
+        return rc == 1
+    end
+    register_getter("headers_sent", headers_sent)
+
+elseif subsystem == 'stream' then
+    _M = new_tab(0, 1)
+
+
+    ffi.cdef[[
+int ngx_stream_lua_ffi_get_conf_env(const unsigned char *name,
+    unsigned char **env_buf, size_t *name_len);
+    ]]
+
+
+    ngx_lua_ffi_get_conf_env = C.ngx_stream_lua_ffi_get_conf_env
+end
+
+
+do
+    local _getenv = os.getenv
+    local env_ptr = ffi_new("unsigned char *[1]")
+
+    os.getenv = function(name)
+        local r = get_request()
+        if r then
+            -- past init_by_lua* phase now
+            os.getenv = _getenv
+            _getenv = nil
+            env_ptr = nil
+            return os.getenv(name)
+        end
+
+        local size = get_string_buf_size()
+        env_ptr[0] = get_string_buf(size)
+        local name_len_ptr = get_size_ptr()
+
+        local rc = ngx_lua_ffi_get_conf_env(name, env_ptr, name_len_ptr)
+        if rc == FFI_OK then
+            return ffi_str(env_ptr[0] + name_len_ptr[0] + 1)
+        end
+
+        -- FFI_DECLINED
+
+        local value = _getenv(name)
+        if value ~= nil then
+            return value
+        end
+
+        return nil
+    end
+end
+
+
 _M._VERSION = base.version
-
-
-local function register_getter(key, func)
-    ngx_magic_key_getters[key] = func
-end
-_M.register_ngx_magic_key_getter = register_getter
-
-
-local function register_setter(key, func)
-    ngx_magic_key_setters[key] = func
-end
-_M.register_ngx_magic_key_setter = register_setter
-
-
-local mt = getmetatable(ngx)
-
-
-local old_index = mt.__index
-mt.__index = function (tb, key)
-    local f = ngx_magic_key_getters[key]
-    if f then
-        return f()
-    end
-    return old_index(tb, key)
-end
-
-
-local old_newindex = mt.__newindex
-mt.__newindex = function (tb, key, ctx)
-    local f = ngx_magic_key_setters[key]
-    if f then
-        return f(ctx)
-    end
-    return old_newindex(tb, key, ctx)
-end
-
-
-ffi.cdef[[
-    int ngx_http_lua_ffi_get_resp_status(ngx_http_request_t *r);
-    int ngx_http_lua_ffi_set_resp_status(ngx_http_request_t *r, int r);
-    int ngx_http_lua_ffi_is_subrequest(ngx_http_request_t *r);
-    int ngx_http_lua_ffi_headers_sent(ngx_http_request_t *r);
-]]
-
-
--- ngx.status
-
-local function get_status()
-    local r = get_request()
-
-    if not r then
-        error("no request found")
-    end
-
-    local rc = C.ngx_http_lua_ffi_get_resp_status(r)
-
-    if rc == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
-    end
-
-    return rc
-end
-register_getter("status", get_status)
-
-
-local function set_status(status)
-    local r = get_request()
-
-    if not r then
-        error("no request found")
-    end
-
-    if type(status) ~= 'number' then
-        status = tonumber(status)
-    end
-
-    local rc = C.ngx_http_lua_ffi_set_resp_status(r, status)
-
-    if rc == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
-    end
-
-    return
-end
-register_setter("status", set_status)
-
-
--- ngx.is_subrequest
-
-local function is_subreq()
-    local r = get_request()
-
-    if not r then
-        error("no request found")
-    end
-
-    local rc = C.ngx_http_lua_ffi_is_subrequest(r)
-
-    if rc == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
-    end
-
-    return rc == 1
-end
-register_getter("is_subrequest", is_subreq)
-
-
--- ngx.headers_sent
-
-local function headers_sent()
-    local r = get_request()
-
-    if not r then
-        error("no request found")
-    end
-
-    local rc = C.ngx_http_lua_ffi_headers_sent(r)
-
-    if rc == FFI_NO_REQ_CTX then
-        error("no request ctx found")
-    end
-
-    if rc == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
-    end
-
-    return rc == 1
-end
-register_getter("headers_sent", headers_sent)
 
 
 return _M

--- a/t/os-getenv-hup.t
+++ b/t/os-getenv-hup.t
@@ -1,0 +1,156 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 4);
+
+my $pwd = cwd();
+
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    my $http_config = $block->http_config || '';
+    my $init_by_lua_block = $block->init_by_lua_block || 'require "resty.core"';
+
+    $http_config .= <<_EOC_;
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+
+    if (!defined $block->error_log) {
+        $block->set_value("error_log",
+                          qr/\[notice\] .*? \(SIGHUP\) received/);
+    }
+
+    if (!defined $block->no_error_log) {
+        $block->set_value("no_error_log", "[error]");
+    }
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+no_shuffle();
+use_hup();
+
+$ENV{TEST_NGINX_BAR} = 'old';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: env directive explicit value is visible within init_by_lua*
+--- main_config
+env FOO=old;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo)
+    }
+}
+--- response_body
+old
+--- error_log
+[notice]
+
+
+
+=== TEST 2: HUP reload changes env value (1/3)
+--- main_config
+env FOO=new;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo)
+    }
+}
+--- response_body
+new
+
+
+
+=== TEST 3: HUP reload changes env value (2/3)
+--- main_config
+env FOO=;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo)
+    }
+}
+--- response_body_like chomp
+\s
+
+
+
+=== TEST 4: HUP reload changes env value (3/3)
+--- main_config
+env FOO;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo)
+    }
+}
+--- response_body
+nil
+
+
+
+=== TEST 5: HUP reload changes visible environment variable (1/2)
+--- main_config
+env TEST_NGINX_BAR;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.test_nginx_bar = os.getenv("TEST_NGINX_BAR")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.test_nginx_bar)
+    }
+}
+--- response_body
+old
+
+
+
+=== TEST 6: HUP reload changes visible environment variable (2/2)
+--- main_config
+env TEST_NGINX_BAR=new;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.test_nginx_bar = os.getenv("TEST_NGINX_BAR")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.test_nginx_bar)
+    }
+}
+--- response_body
+new

--- a/t/os-getenv.t
+++ b/t/os-getenv.t
@@ -1,0 +1,197 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+my $pwd = cwd();
+
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    my $http_config = $block->http_config || '';
+    my $init_by_lua_block = $block->init_by_lua_block || 'require "resty.core"';
+
+    $http_config .= <<_EOC_;
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+
+    if (!defined $block->error_log) {
+        $block->set_value("no_error_log", "[error]");
+    }
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+$ENV{TEST_NGINX_BAR} = 'world';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: env directive explicit value is visible within init_by_lua*
+--- main_config
+env FOO=hello;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("FOO"))
+    }
+}
+--- response_body
+hello
+hello
+
+
+
+=== TEST 2: env directive explicit value is visible within init_by_lua* with lua_shared_dict
+--- main_config
+env FOO=hello;
+--- http_config
+    lua_shared_dict dogs 24k;
+
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("FOO"))
+    }
+}
+--- response_body
+hello
+hello
+
+
+
+=== TEST 3: env directive explicit value is case-sensitive within init_by_lua*
+--- main_config
+env FOO=hello;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("foo")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("foo"))
+    }
+}
+--- response_body
+nil
+nil
+
+
+
+=== TEST 4: env directives with no value are ignored
+--- main_config
+env FOO;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("FOO"))
+    }
+}
+--- response_body
+nil
+nil
+
+
+
+=== TEST 5: env is visible from environment
+--- main_config
+env TEST_NGINX_BAR;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("TEST_NGINX_BAR")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("TEST_NGINX_BAR"))
+    }
+}
+--- response_body
+world
+world
+
+
+
+=== TEST 6: env explicit set vs environment set
+--- main_config
+env TEST_NGINX_BAR=goodbye;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("TEST_NGINX_BAR")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("TEST_NGINX_BAR"))
+    }
+}
+--- response_body
+goodbye
+goodbye
+
+
+
+=== TEST 7: env directive with empty value
+--- main_config
+env FOO=;
+--- http_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        ngx.say("in init: ", package.loaded.foo, "\n",
+                "in content: ", os.getenv("FOO"))
+    }
+}
+--- response_body_like
+in init:\s+
+in content:\s+
+
+
+
+=== TEST 8: os.getenv() overwrite is reverted in worker phases
+--- http_config
+    init_by_lua_block {
+        package.loaded.os_getenv = os.getenv
+        require "resty.core"
+        package.loaded.is_os_getenv = os.getenv == package.loaded.os_getenv
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        os.getenv("")
+
+        ngx.say("in init: ", package.loaded.is_os_getenv, "\n",
+                "in content: ", os.getenv == package.loaded.os_getenv)
+    }
+}
+--- response_body
+in init: false
+in content: true

--- a/t/stream/os-getenv-hup.t
+++ b/t/stream/os-getenv-hup.t
@@ -1,0 +1,131 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use Test::Nginx::Socket::Lua::Stream;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 2 + 1);
+
+my $pwd = cwd();
+
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    my $stream_config = $block->stream_config || '';
+
+    $stream_config .= <<_EOC_;
+
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+_EOC_
+
+    $block->set_value("stream_config", $stream_config);
+});
+
+no_shuffle();
+use_hup();
+
+$ENV{TEST_NGINX_BAR} = 'old';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: env directive explicit value is visible within init_by_lua*
+--- main_config
+env FOO=old;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo)
+    }
+--- stream_response
+old
+--- error_log
+[notice]
+
+
+
+=== TEST 2: HUP reload changes env value (1/3)
+--- main_config
+env FOO=new;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo)
+    }
+--- stream_response
+new
+
+
+
+=== TEST 3: HUP reload changes env value (2/3)
+--- main_config
+env FOO=;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo)
+    }
+--- stream_response_like chomp
+\s
+
+
+
+=== TEST 4: HUP reload changes env value (3/3)
+--- main_config
+env FOO;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo)
+    }
+--- stream_response
+nil
+
+
+
+=== TEST 5: HUP reload changes visible environment variable (1/2)
+--- main_config
+env TEST_NGINX_BAR;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.test_nginx_bar = os.getenv("TEST_NGINX_BAR")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.test_nginx_bar)
+    }
+--- stream_response
+old
+
+
+
+=== TEST 6: HUP reload changes visible environment variable (2/2)
+--- main_config
+env TEST_NGINX_BAR=new;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.test_nginx_bar = os.getenv("TEST_NGINX_BAR")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.test_nginx_bar)
+    }
+--- stream_response
+new

--- a/t/stream/os-getenv.t
+++ b/t/stream/os-getenv.t
@@ -1,0 +1,174 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use Test::Nginx::Socket::Lua::Stream;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 2);
+
+my $pwd = cwd();
+
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    my $stream_config = $block->stream_config || '';
+
+    $stream_config .= <<_EOC_;
+
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+_EOC_
+
+    $block->set_value("stream_config", $stream_config);
+});
+
+
+$ENV{TEST_NGINX_BAR} = 'world';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: env directive explicit value is visible within init_by_lua*
+--- main_config
+env FOO=hello;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("FOO"))
+    }
+--- stream_response
+hello
+hello
+
+
+
+=== TEST 2: env directive explicit value is visible within init_by_lua* with lua_shared_dict
+--- main_config
+env FOO=hello;
+--- stream_config
+    lua_shared_dict dogs 24k;
+
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("FOO"))
+    }
+--- stream_response
+hello
+hello
+
+
+
+=== TEST 3: env directive explicit value is case-sensitive within init_by_lua*
+--- main_config
+env FOO=hello;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("foo")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("foo"))
+    }
+--- stream_response
+nil
+nil
+
+
+
+=== TEST 4: env directives with no value are ignored
+--- main_config
+env FOO;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("FOO"))
+    }
+--- stream_response
+nil
+nil
+
+
+
+=== TEST 5: env is visible from environment
+--- main_config
+env TEST_NGINX_BAR;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("TEST_NGINX_BAR")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("TEST_NGINX_BAR"))
+    }
+--- stream_response
+world
+world
+
+
+
+=== TEST 6: env explicit set vs environment set
+--- main_config
+env TEST_NGINX_BAR=goodbye;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("TEST_NGINX_BAR")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say(package.loaded.foo, "\n", os.getenv("TEST_NGINX_BAR"))
+    }
+--- stream_response
+goodbye
+goodbye
+
+
+
+=== TEST 7: env directive with empty value
+--- main_config
+env FOO=;
+--- stream_config
+    init_by_lua_block {
+        require "resty.core"
+        package.loaded.foo = os.getenv("FOO")
+    }
+--- stream_server_config
+    content_by_lua_block {
+        ngx.say("in init: ", package.loaded.foo, "\n",
+                "in content: ", os.getenv("FOO"))
+    }
+--- stream_response_like
+in init:\s+
+in content:\s+
+
+
+
+=== TEST 8: os.getenv() overwrite is reverted in worker phases
+--- stream_config
+    init_by_lua_block {
+        package.loaded.os_getenv = os.getenv
+        require "resty.core"
+        package.loaded.is_os_getenv = os.getenv == package.loaded.os_getenv
+    }
+--- stream_server_config
+    content_by_lua_block {
+        os.getenv("")
+
+        ngx.say("in init: ", package.loaded.is_os_getenv, "\n",
+                "in content: ", os.getenv == package.loaded.os_getenv)
+    }
+--- stream_response
+in init: false
+in content: true


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

Sister PR: https://github.com/openresty/lua-nginx-module/pull/1343
