### PR TITLE
change: when subsystem violation occurs, print what the offending mod…

### DIFF
--- a/lib/resty/core/base.lua
+++ b/lib/resty/core/base.lua
@@ -219,7 +219,7 @@ function _M.allows_subsystem(...)
         end
     end
 
-    error("unsupported subsystem: " .. subsystem)
+    error("unsupported subsystem: " .. subsystem, 2)
 end
 
 


### PR DESCRIPTION
…ule is.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
