### PR TITLE
tests: $init_by_lua_block should be used inside the template in ngx-resp.t.

### DIFF
--- a/t/ngx-resp.t
+++ b/t/ngx-resp.t
@@ -27,7 +27,7 @@ add_block_preprocessor(sub {
             v.on("$Test::Nginx::Util::ErrLogFile")
         end
 
-        require "resty.core"
+        $init_by_lua_block
     }
 _EOC_
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
