### PR TITLE
bugfix: ngx.resp: resp.add_header should reject empty table header va…

### DIFF
--- a/lib/ngx/resp.md
+++ b/lib/ngx/resp.md
@@ -59,7 +59,10 @@ add_header
 **syntax:** *ngx_resp.add_header(header_name, header_value)*
 
 This function adds specified header with corresponding value to the response of
-current request. The `header_value` could be either a string or a table.
+current request. The `header_value` could be either a string or a non-empty table.
+
+Pass `nil` or `{}` as `header_value` will throw out the Lua exception
+`invalid header value`.
 
 The `ngx.resp.add_header` works mostly like:
 * [ngx.header.HEADER](https://github.com/openresty/lua-nginx-module#ngxheaderheader)

--- a/lib/ngx/resp.md
+++ b/lib/ngx/resp.md
@@ -59,10 +59,7 @@ add_header
 **syntax:** *ngx_resp.add_header(header_name, header_value)*
 
 This function adds specified header with corresponding value to the response of
-current request. The `header_value` could be either a string or a non-empty table.
-
-Pass `nil` or `{}` as `header_value` will throw out the Lua exception
-`invalid header value`.
+current request. The `header_value` could be either a string or a table.
 
 The `ngx.resp.add_header` works mostly like:
 * [ngx.header.HEADER](https://github.com/openresty/lua-nginx-module#ngxheaderheader)

--- a/lib/resty/core/response.lua
+++ b/lib/resty/core/response.lua
@@ -69,7 +69,7 @@ local function set_resp_header(tb, key, value, no_override)
         if type(value) == "table" then
             mvals_len = #value
             if mvals_len == 0 and no_override then
-                error("invalid header value", 3)
+                return
             end
 
             buf = get_string_buf(ffi_str_size * mvals_len)

--- a/lib/resty/core/response.lua
+++ b/lib/resty/core/response.lua
@@ -68,6 +68,10 @@ local function set_resp_header(tb, key, value, no_override)
 
         if type(value) == "table" then
             mvals_len = #value
+            if mvals_len == 0 and no_override then
+                error("invalid header value", 3)
+            end
+
             buf = get_string_buf(ffi_str_size * mvals_len)
             mvals = ffi_cast(ffi_str_type, buf)
             for i = 1, mvals_len do

--- a/t/ngx-resp.t
+++ b/t/ngx-resp.t
@@ -101,3 +101,22 @@ fruit: apple, banana, cherry
     }
 --- response_body
 Date: now
+
+
+
+=== TEST 6: ngx.resp.add_header ({})
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_resp = require "ngx.resp"
+            ngx.header['Foo'] = 'aaa'
+            local ok, err = pcall(ngx_resp.add_header, "Foo", {})
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("Foo: ", ngx.header["Foo"])
+            end
+        }
+    }
+--- response_body
+invalid header value

--- a/t/ngx-resp.t
+++ b/t/ngx-resp.t
@@ -119,4 +119,4 @@ Date: now
         }
     }
 --- response_body
-invalid header value
+Foo: aaa


### PR DESCRIPTION
…lue.

Pass an empty table as header value is meaningless as no header will be
added.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
