### PR TITLE
feature: implemented ngx.req module and its function add_header().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b ngx_req_add_header https://github.com/spacewander/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/lib/ngx/req.lua
+++ b/lib/ngx/req.lua
@@ -1,0 +1,18 @@
+-- Copyright (C) by OpenResty Inc.
+
+
+local base = require "resty.core.base"
+base.allows_subsystem('http')
+local core_request = require "resty.core.request"
+local set_req_header = core_request.set_req_header
+
+
+local _M = { version = base.version }
+
+
+function _M.add_header(key, value)
+    set_req_header(key, value, false)
+end
+
+
+return _M

--- a/lib/ngx/req.md
+++ b/lib/ngx/req.md
@@ -1,0 +1,133 @@
+Name
+====
+
+ngx.req - Lua API for HTTP request handling.
+
+Table of Contents
+=================
+
+* [Name](#name)
+* [Status](#status)
+* [Synopsis](#synopsis)
+* [Description](#description)
+* [Methods](#methods)
+    * [add_header](#add_header)
+* [Community](#community)
+    * [English Mailing List](#english-mailing-list)
+    * [Chinese Mailing List](#chinese-mailing-list)
+* [Bugs and Patches](#bugs-and-patches)
+* [Copyright and License](#copyright-and-license)
+* [See Also](#see-also)
+
+Status
+======
+
+This Lua module is currently considered experimental.
+
+Synopsis
+========
+
+```lua
+local ngx_req = require "ngx.req"
+
+-- add_header
+ngx_req.add_header("Foo", "bar")
+ngx_req.add_header("Foo", "baz")
+--> there will be two new headers in HTTP request:
+--> Foo: bar and Foo: baz
+```
+
+[Back to TOC](#table-of-contents)
+
+Description
+===========
+
+This Lua module provides Lua API which could be used to handle HTTP request.
+
+[Back to TOC](#table-of-contents)
+
+Methods
+=======
+
+All the methods of this module are static (or module-level). That is, you do
+not need an object (or instance) to call these methods.
+
+[Back to TOC](#table-of-contents)
+
+add_header
+----------
+**syntax:** *ngx_req.add_header(header_name, header_value)*
+
+This method adds specified header with corresponding value to the current
+request. The `header_value` could be either a string or a non-empty table.
+
+The `ngx.req.add_header` works mostly like
+[ngx.req.set_header](https://github.com/openresty/lua-nginx-module#ngxreqset_header)
+
+However, unlike `ngx.req.set_header`, this method appends new header to the old
+one instead of overriding it if the header is not builtin.
+
+For the builtin header, this method overrides it instead of appending to it.
+IMHO, it is reasonable since appending to the builtin header like `User-Agent`
+is confusing and semantically wrong.
+
+[Back to TOC](#table-of-contents)
+
+Community
+=========
+
+[Back to TOC](#table-of-contents)
+
+English Mailing List
+--------------------
+
+The [openresty-en](https://groups.google.com/group/openresty-en) mailing list
+is for English speakers.
+
+[Back to TOC](#table-of-contents)
+
+Chinese Mailing List
+--------------------
+
+The [openresty](https://groups.google.com/group/openresty) mailing list is for
+Chinese speakers.
+
+[Back to TOC](#table-of-contents)
+
+Bugs and Patches
+================
+
+Please report bugs or submit patches by
+
+1. creating a ticket on the [GitHub Issue Tracker](https://github.com/openresty/lua-resty-core/issues),
+1. or posting to the [OpenResty community](#community).
+
+[Back to TOC](#table-of-contents)
+
+Copyright and License
+=====================
+
+This module is licensed under the BSD license.
+
+Copyright (C) 2018, by Yichun "agentzh" Zhang, OpenResty Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[Back to TOC](#table-of-contents)
+
+See Also
+========
+* library [lua-resty-core](https://github.com/openresty/lua-resty-core)
+* the ngx_lua module: https://github.com/openresty/lua-nginx-module
+* OpenResty: http://openresty.org
+
+[Back to TOC](#table-of-contents)
+

--- a/t/ngx-req.t
+++ b/t/ngx-req.t
@@ -27,7 +27,7 @@ add_block_preprocessor(sub {
             v.on("$Test::Nginx::Util::ErrLogFile")
         end
 
-        require "resty.core"
+        $init_by_lua_block
     }
 _EOC_
 

--- a/t/ngx-req.t
+++ b/t/ngx-req.t
@@ -124,22 +124,7 @@ UA: Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/13.0 Firefox/13.0
 
 
 
-=== TEST 5: ngx.req.add_header (multiple value)
---- config
-    location = /t {
-        content_by_lua_block {
-            local ngx_req = require "ngx.req"
-            ngx.req.set_header("Foo", "bar")
-            ngx_req.add_header("Foo", {"baz", 2})
-            ngx.say("Foo: ", table.concat(ngx.req.get_headers()["Foo"], ", "))
-        }
-    }
---- response_body
-Foo: bar, baz, 2
-
-
-
-=== TEST 5: ngx.req.add_header (multiple value)
+=== TEST 5: ngx.req.add_header (multiple values)
 --- config
     location = /t {
         content_by_lua_block {

--- a/t/ngx-req.t
+++ b/t/ngx-req.t
@@ -1,0 +1,190 @@
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 3 + 2);
+
+my $pwd = cwd();
+
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    my $http_config = $block->http_config || '';
+    my $init_by_lua_block = $block->init_by_lua_block || 'require "resty.core"';
+
+    $http_config .= <<_EOC_;
+
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+    init_by_lua_block {
+        local verbose = false
+        if verbose then
+            local dump = require "jit.dump"
+            dump.on("b", "$Test::Nginx::Util::ErrLogFile")
+        else
+            local v = require "jit.v"
+            v.on("$Test::Nginx::Util::ErrLogFile")
+        end
+
+        require "resty.core"
+    }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+
+    if (!defined $block->error_log) {
+        $block->set_value("no_error_log", "[error]");
+    }
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+});
+
+no_long_string();
+check_accum_error_log();
+run_tests();
+
+__DATA__
+
+=== TEST 1: ngx.req.add_header (jitted)
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_req = require "ngx.req"
+            for i = 1, 500 do
+                ngx_req.add_header("Foo", "bar")
+            end
+        }
+    }
+--- error_log eval
+qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):3 loop\]/
+--- no_error_log
+[error]
+bad argument type
+stitch
+
+
+
+=== TEST 2: ngx.req.add_header (single value)
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_req = require "ngx.req"
+            ngx.req.set_header("Foo", "bar")
+            ngx_req.add_header("Foo", "baz")
+            ngx_req.add_header("Foo", 2)
+            ngx.say("Foo: ", table.concat(ngx.req.get_headers()["Foo"], ", "))
+        }
+    }
+--- response_body
+Foo: bar, baz, 2
+
+
+
+=== TEST 3: ngx.req.add_header (invalid header value: nil, {})
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_req = require "ngx.req"
+            local function check_invalid_header_value(...)
+                local ok, err = pcall(ngx_req.add_header, "Foo", ...)
+                if not ok then
+                    ngx.say(err)
+                else
+                    ngx.say('ok')
+                end
+            end
+
+            check_invalid_header_value()
+            check_invalid_header_value(nil)
+            check_invalid_header_value({})
+        }
+    }
+--- response_body
+invalid header value
+invalid header value
+invalid header value
+
+
+
+=== TEST 4: ngx.resp.add_header (override builtin header)
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_req = require "ngx.req"
+            ngx_req.add_header("User-Agent", "Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/13.0 Firefox/13.0")
+            ngx.say("UA: ", ngx.var.http_user_agent)
+        }
+    }
+--- response_body
+UA: Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/13.0 Firefox/13.0
+
+
+
+=== TEST 5: ngx.req.add_header (multiple value)
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_req = require "ngx.req"
+            ngx.req.set_header("Foo", "bar")
+            ngx_req.add_header("Foo", {"baz", 2})
+            ngx.say("Foo: ", table.concat(ngx.req.get_headers()["Foo"], ", "))
+        }
+    }
+--- response_body
+Foo: bar, baz, 2
+
+
+
+=== TEST 5: ngx.req.add_header (multiple value)
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_req = require "ngx.req"
+            ngx.req.set_header("Foo", "bar")
+            ngx_req.add_header("Foo", {"baz", 2})
+            ngx.say("Foo: ", table.concat(ngx.req.get_headers()["Foo"], ", "))
+        }
+    }
+--- response_body
+Foo: bar, baz, 2
+
+
+
+=== TEST 6: added header is inherited by the subrequest
+--- config
+    location = /sub {
+        content_by_lua_block {
+            ngx.say("Foo: ", table.concat(ngx.req.get_headers()["Foo"], ", "))
+        }
+    }
+
+    location = /t {
+        content_by_lua_block {
+            local ngx_req = require "ngx.req"
+            ngx.req.set_header("Foo", "bar")
+            ngx_req.add_header("Foo", {"baz", 2})
+            res = ngx.location.capture("/sub")
+            ngx.print(res.body)
+        }
+    }
+--- response_body
+Foo: bar, baz, 2
+
+
+
+=== TEST 7: ngx.req.add_header ('')
+--- config
+    location = /t {
+        content_by_lua_block {
+            local ngx_req = require "ngx.req"
+            ngx.req.set_header("Foo", "bar")
+            ngx_req.add_header("Foo", '')
+            ngx.say("Foo: [", table.concat(ngx.req.get_headers()["Foo"], ", "), ']')
+        }
+    }
+--- response_body
+Foo: [bar, ]


### PR DESCRIPTION
The `ngx.req.add_header` works mostly like `ngx.req.set_header`.
However, unlike `ngx.req.set_header`, this method appends new header to the old
one instead of overriding it if the header is not builtin.

For the builtin header, this method overrides it instead of appending to it.
IMHO, it is reasonable since appending to the builtin header like `User-Agent`
is confusing and semantically wrong.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
