### PR TITLE
doc: ngx.process: 'priviledged' should be privileged.

### DIFF
--- a/lib/ngx/process.md
+++ b/lib/ngx/process.md
@@ -121,7 +121,7 @@ enable_privileged_agent
 
 Enables the privileged agent process in Nginx.
 
-The priviledged agent process does not listen on any virtual server ports like those worker processes.
+The privileged agent process does not listen on any virtual server ports like those worker processes.
 And it uses the same system account as the nginx master process, which is usually a privileged account
 like `root`.
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
