### PR TITLE
misc: gitignore: add parallel tests servroots.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.swo
 *~
 go
-t/servroot/
+t/servroot*
 reindex
 nginx
 ctags


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.


Ignore test servroots such as t/servroot_11588/ generated when running
the test suite with TEST_NGINX_RANDOMIZE=1.