### PR TITLE
tests: shdict.t: hardened 'init_ttl' test cases to ensure keys expire.

### DIFF
--- a/t/shdict.t
+++ b/t/shdict.t
@@ -317,6 +317,7 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):7 loop\]/
                 ngx.say("failed to set: ", err)
                 return
             end
+            ngx.update_time()
             ngx.sleep(0.002)
             for i = 1, 100 do
                 val, flags, stale = dogs:get_stale("foo")
@@ -1377,6 +1378,7 @@ not ok: must provide "init" when providing "init_ttl"
             ngx.say("incr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
 
+            ngx.update_time()
             ngx.sleep(0.002)
 
             ngx.say("foo after incr init_ttl = ", dogs:get("foo"))
@@ -1407,6 +1409,7 @@ foo after incr init_ttl = 10534
             ngx.say("incr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
 
+            ngx.update_time()
             ngx.sleep(0.002)
 
             ngx.say("foo after init_ttl = ", dogs:get("foo"))
@@ -1437,6 +1440,7 @@ foo after init_ttl = nil
             ngx.say("incr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
 
+            ngx.update_time()
             ngx.sleep(0.002)
 
             ngx.say("foo after init_ttl = ", dogs:get("foo"))
@@ -1465,12 +1469,14 @@ foo after init_ttl = nil
                 dogs:set("bar" .. i, i, 0.002)
             end
             dogs:set("foo", 32, 0.002)
+            ngx.update_time()
             ngx.sleep(0.003)
 
             local res, err = dogs:incr("foo", 10502, 0, 0.001)
             ngx.say("incr: ", res, " ", err)
             ngx.say("foo = ", dogs:get("foo"))
 
+            ngx.update_time()
             ngx.sleep(0.002)
 
             ngx.say("foo after init_ttl = ", dogs:get("foo"))
@@ -1513,6 +1519,7 @@ foo after init_ttl = nil
             ngx.say("incr: ", res, " ", err, " ", forcible)
             ngx.say("foo = ", dogs:get(long_prefix .. "foo"))
 
+            ngx.update_time()
             ngx.sleep(0.002)
             ngx.say("foo after init_ttl = ", dogs:get("foo"))
         }

--- a/t/stream/shdict.t
+++ b/t/stream/shdict.t
@@ -284,6 +284,7 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):7 loop\]/
             ngx.say("failed to set: ", err)
             return
         end
+        ngx.update_time()
         ngx.sleep(0.002)
         for i = 1, 30 do
             val, flags, stale = dogs:get_stale("foo")
@@ -1208,6 +1209,7 @@ not ok: must provide "init" when providing "init_ttl"
         ngx.say("incr: ", res, " ", err)
         ngx.say("foo = ", dogs:get("foo"))
 
+        ngx.update_time()
         ngx.sleep(0.002)
 
         ngx.say("foo after incr init_ttl = ", dogs:get("foo"))
@@ -1234,6 +1236,7 @@ foo after incr init_ttl = 10534
         ngx.say("incr: ", res, " ", err)
         ngx.say("foo = ", dogs:get("foo"))
 
+        ngx.update_time()
         ngx.sleep(0.002)
 
         ngx.say("foo after init_ttl = ", dogs:get("foo"))
@@ -1260,6 +1263,7 @@ foo after init_ttl = nil
         ngx.say("incr: ", res, " ", err)
         ngx.say("foo = ", dogs:get("foo"))
 
+        ngx.update_time()
         ngx.sleep(0.002)
 
         ngx.say("foo after init_ttl = ", dogs:get("foo"))
@@ -1284,12 +1288,14 @@ foo after init_ttl = nil
             dogs:set("bar" .. i, i, 0.002)
         end
         dogs:set("foo", 32, 0.002)
+        ngx.update_time()
         ngx.sleep(0.003)
 
         local res, err = dogs:incr("foo", 10502, 0, 0.001)
         ngx.say("incr: ", res, " ", err)
         ngx.say("foo = ", dogs:get("foo"))
 
+        ngx.update_time()
         ngx.sleep(0.002)
 
         ngx.say("foo after init_ttl = ", dogs:get("foo"))
@@ -1328,6 +1334,7 @@ foo after init_ttl = nil
         ngx.say("incr: ", res, " ", err, " ", forcible)
         ngx.say("foo = ", dogs:get(long_prefix .. "foo"))
 
+        ngx.update_time()
         ngx.sleep(0.002)
         ngx.say("foo after init_ttl = ", dogs:get("foo"))
     }


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
