### PR TITLE
tests: avoided listening on 127.0.0.2:12345 on which iptables drops packets for ngx_lua and ngx_stream_lua tests suites.

### DIFF
--- a/t/ndk.t
+++ b/t/ndk.t
@@ -5,8 +5,6 @@ repeat_each(2);
 
 plan tests => repeat_each() * (blocks() * 5 + 2);
 
-$ENV{TEST_NGINX_HOTLOOP} ||= 9;
-
 add_block_preprocessor(sub {
     my $block = shift;
 
@@ -47,11 +45,11 @@ __DATA__
             ngx.say(set_unescape_uri("a%20b"))
 
             local res
-            for i = 1, $TEST_NGINX_HOTLOOP * 5 do
+            for i = 1, $TEST_NGINX_HOTLOOP * 10 do
                 res = set_escape_uri(" :")
             end
 
-            for i = 1, $TEST_NGINX_HOTLOOP * 5 do
+            for i = 1, $TEST_NGINX_HOTLOOP * 10 do
                 res = set_unescape_uri("a%20b")
             end
         }

--- a/t/ocsp.t
+++ b/t/ocsp.t
@@ -1403,7 +1403,7 @@ FIXME: check the OCSP staple actually received by the ssl client
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         server_name test.com;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
@@ -1444,7 +1444,7 @@ FIXME: check the OCSP staple actually received by the ssl client
 
                 sock:settimeout(3000)
 
-                local ok, err = sock:connect("127.0.0.2", 12345)
+                local ok, err = sock:connect("127.0.0.2", 23456)
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1485,7 +1485,7 @@ ocsp status resp set ok: nil,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         server_name test.com;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
@@ -1526,7 +1526,7 @@ ocsp status resp set ok: nil,
 
                 sock:settimeout(3000)
 
-                local ok, err = sock:connect("127.0.0.2", 12345)
+                local ok, err = sock:connect("127.0.0.2", 23456)
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -1042,7 +1042,7 @@ lua ssl server name: "test.com"
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         server_name test.com;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
@@ -1078,7 +1078,7 @@ lua ssl server name: "test.com"
 
                 sock:settimeout(3000)
 
-                local ok, err = sock:connect("127.0.0.2", 12345)
+                local ok, err = sock:connect("127.0.0.2", 23456)
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1118,7 +1118,7 @@ got TLS1 version: SSLv3,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         server_name test.com;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
@@ -1154,7 +1154,7 @@ got TLS1 version: SSLv3,
 
                 sock:settimeout(3000)
 
-                local ok, err = sock:connect("127.0.0.2", 12345)
+                local ok, err = sock:connect("127.0.0.2", 23456)
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1194,7 +1194,7 @@ got TLS1 version: TLSv1,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         server_name test.com;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
@@ -1230,7 +1230,7 @@ got TLS1 version: TLSv1,
 
                 sock:settimeout(3000)
 
-                local ok, err = sock:connect("127.0.0.2", 12345)
+                local ok, err = sock:connect("127.0.0.2", 23456)
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1270,7 +1270,7 @@ got TLS1 version: TLSv1.1,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         server_name test.com;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
@@ -1306,7 +1306,7 @@ got TLS1 version: TLSv1.1,
 
                 sock:settimeout(3000)
 
-                local ok, err = sock:connect("127.0.0.2", 12345)
+                local ok, err = sock:connect("127.0.0.2", 23456)
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return
@@ -1346,7 +1346,7 @@ got TLS1 version: TLSv1.2,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         server_name test.com;
         ssl_certificate_by_lua_block {
             local semaphore = require "ngx.semaphore"
@@ -1389,7 +1389,7 @@ got TLS1 version: TLSv1.2,
 
                 sock:settimeout(3000)
 
-                local ok, err = sock:connect("127.0.0.2", 12345)
+                local ok, err = sock:connect("127.0.0.2", 23456)
                 if not ok then
                     ngx.say("failed to connect: ", err)
                     return

--- a/t/stream/ssl.t
+++ b/t/stream/ssl.t
@@ -806,7 +806,7 @@ lua ssl server name: "test.com"
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
@@ -834,7 +834,7 @@ lua ssl server name: "test.com"
 
             sock:settimeout(3000)
 
-            local ok, err = sock:connect("127.0.0.2", 12345)
+            local ok, err = sock:connect("127.0.0.2", 23456)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return
@@ -871,7 +871,7 @@ got TLS1 version: SSLv3,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
@@ -899,7 +899,7 @@ got TLS1 version: SSLv3,
 
             sock:settimeout(3000)
 
-            local ok, err = sock:connect("127.0.0.2", 12345)
+            local ok, err = sock:connect("127.0.0.2", 23456)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return
@@ -936,7 +936,7 @@ got TLS1 version: TLSv1,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
@@ -964,7 +964,7 @@ got TLS1 version: TLSv1,
 
             sock:settimeout(3000)
 
-            local ok, err = sock:connect("127.0.0.2", 12345)
+            local ok, err = sock:connect("127.0.0.2", 23456)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return
@@ -1001,7 +1001,7 @@ got TLS1 version: TLSv1.1,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
@@ -1029,7 +1029,7 @@ got TLS1 version: TLSv1.1,
 
             sock:settimeout(3000)
 
-            local ok, err = sock:connect("127.0.0.2", 12345)
+            local ok, err = sock:connect("127.0.0.2", 23456)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return
@@ -1066,7 +1066,7 @@ got TLS1 version: TLSv1.2,
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
 
     server {
-        listen 127.0.0.2:12345 ssl;
+        listen 127.0.0.2:23456 ssl;
         ssl_certificate_by_lua_block {
             local semaphore = require "ngx.semaphore"
 
@@ -1101,7 +1101,7 @@ got TLS1 version: TLSv1.2,
 
             sock:settimeout(3000)
 
-            local ok, err = sock:connect("127.0.0.2", 12345)
+            local ok, err = sock:connect("127.0.0.2", 23456)
             if not ok then
                 ngx.say("failed to connect: ", err)
                 return


### PR DESCRIPTION
On our AWS EC2 test cluster, these tests fail if the lua-resty-core test
suite gets executed on an instance also executing the ngx_lua or
ngx_stream_lua test suites, since the latter two have iptables rules to
drop packet on this specific IP/port couple.

Instead of removing the rule from opsboy, changing the port here will
also ease local development process for maintainers. Only lua-resty-core
seems to be using this IP/port couple from the OpenResty components.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
