### PR TITLE
tests: pipe.t: checked the behavior of ngx.pipe.spawn when error_log …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ env:
     - NGINX_VERSION=1.15.8 OPENSSL_VER=1.0.2n OPENSSL_PATCH_VER=1.0.2h
     - NGINX_VERSION=1.15.8 OPENSSL_VER=1.1.0h OPENSSL_PATCH_VER=1.1.0d
 
+services:
+  - memcache
+
 before_install:
   - sudo luarocks install luacheck $LUACHECK_VER
   - luacheck -q .

--- a/t/TestCore.pm
+++ b/t/TestCore.pm
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua -Base;
 use Cwd qw(cwd);
 
 $ENV{TEST_NGINX_HOTLOOP} ||= 10;
+$ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 
 our $pwd = cwd();
 


### PR DESCRIPTION
…is configured to use syslog.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
