### PR TITLE
misc: updated calls to 'error()' to be thrown from the user's stack level.

### DIFF
--- a/lib/ngx/errlog.lua
+++ b/lib/ngx/errlog.lua
@@ -162,7 +162,7 @@ function _M.raw_log(level, msg)
     local rc = ngx_lua_ffi_raw_log(r, level, msg, #msg)
 
     if rc == FFI_ERROR then
-        error("bad log level")
+        error("bad log level", 2)
     end
 end
 

--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -289,7 +289,7 @@ function _M.opt(option, value)
     if option == "jit_stack_size" then
         if not is_regex_cache_empty() then
             error("changing jit stack size is not allowed when some " ..
-                  "regexs have already been compiled and cached")
+                  "regexs have already been compiled and cached", 2)
         end
 
         local errbuf = get_string_buf(MAX_ERR_MSG_LEN)
@@ -302,10 +302,10 @@ function _M.opt(option, value)
             return
         end
 
-        error(ffi_str(errbuf, sizep[0]))
+        error(ffi_str(errbuf, sizep[0]), 2)
     end
 
-    error("unrecognized option name")
+    error("unrecognized option name", 2)
 end
 
 

--- a/lib/resty/core/exit.lua
+++ b/lib/resty/core/exit.lua
@@ -39,7 +39,7 @@ ngx.exit = function (rc)
     if rc == FFI_DONE then
         return
     end
-    error(ffi_string(err, errlen[0]))
+    error(ffi_string(err, errlen[0]), 2)
 end
 
 

--- a/lib/resty/core/misc.lua
+++ b/lib/resty/core/misc.lua
@@ -97,7 +97,7 @@ int ngx_http_lua_ffi_get_conf_env(const unsigned char *name,
         local rc = C.ngx_http_lua_ffi_get_resp_status(r)
 
         if rc == FFI_BAD_CONTEXT then
-            error("API disabled in the current context")
+            error("API disabled in the current context", 2)
         end
 
         return rc
@@ -119,7 +119,7 @@ int ngx_http_lua_ffi_get_conf_env(const unsigned char *name,
         local rc = C.ngx_http_lua_ffi_set_resp_status(r, status)
 
         if rc == FFI_BAD_CONTEXT then
-            error("API disabled in the current context")
+            error("API disabled in the current context", 2)
         end
 
         return
@@ -139,7 +139,7 @@ int ngx_http_lua_ffi_get_conf_env(const unsigned char *name,
         local rc = C.ngx_http_lua_ffi_is_subrequest(r)
 
         if rc == FFI_BAD_CONTEXT then
-            error("API disabled in the current context")
+            error("API disabled in the current context", 2)
         end
 
         return rc == 1
@@ -163,7 +163,7 @@ int ngx_http_lua_ffi_get_conf_env(const unsigned char *name,
         end
 
         if rc == FFI_BAD_CONTEXT then
-            error("API disabled in the current context")
+            error("API disabled in the current context", 2)
         end
 
         return rc == 1

--- a/lib/resty/core/phase.lua
+++ b/lib/resty/core/phase.lua
@@ -41,7 +41,7 @@ function ngx.get_phase()
 
     local context = C.ngx_http_lua_ffi_get_phase(r, errmsg)
     if context == FFI_ERROR then -- NGX_ERROR
-        error(errmsg)
+        error(errmsg, 2)
     end
 
     local phase = context_names[context]

--- a/lib/resty/core/regex.lua
+++ b/lib/resty/core/regex.lua
@@ -327,7 +327,8 @@ local function parse_regex_opts(opts)
             pcre_opts = bor(pcre_opts, PCRE_JAVASCRIPT_COMPAT)
 
         else
-            error(fmt('unknown flag "%s" (flags "%s")', sub(opts, i, i), opts))
+            error(fmt('unknown flag "%s" (flags "%s")', sub(opts, i, i), opts),
+                  3)
         end
     end
 

--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -92,7 +92,7 @@ function ngx.req.get_headers(max_headers, raw)
     local n = C.ngx_http_lua_ffi_req_get_headers_count(r, max_headers,
                                                        truncated)
     if n == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
+        error("API disabled in the current context", 2)
     end
 
     if n == 0 then
@@ -154,7 +154,7 @@ function ngx.req.get_uri_args(max_args)
 
     local n = C.ngx_http_lua_ffi_req_get_uri_args_count(r, max_args, truncated)
     if n == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
+        error("API disabled in the current context", 2)
     end
 
     if n == 0 then
@@ -244,7 +244,7 @@ do
         do
             local id = C.ngx_http_lua_ffi_req_get_method(r)
             if id == FFI_BAD_CONTEXT then
-                error("API disabled in the current context")
+                error("API disabled in the current context", 2)
             end
 
             local method = methods[id]
@@ -280,11 +280,11 @@ function ngx.req.set_method(method)
     end
 
     if rc == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
+        error("API disabled in the current context", 2)
     end
 
     if rc == FFI_DECLINED then
-        error("unsupported HTTP method: " .. method)
+        error("unsupported HTTP method: " .. method, 2)
     end
 
     error("unknown error: " .. rc)
@@ -327,7 +327,7 @@ do
         end
 
         if rc == FFI_BAD_CONTEXT then
-            error("API disabled in the current context")
+            error("API disabled in the current context", 2)
         end
 
         error("error")
@@ -353,7 +353,7 @@ function ngx.req.clear_header(name)
     end
 
     if rc == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
+        error("API disabled in the current context", 2)
     end
 
     error("error")

--- a/lib/resty/core/response.lua
+++ b/lib/resty/core/response.lua
@@ -109,11 +109,11 @@ local function set_resp_header(tb, key, value, no_override)
     end
 
     if rc == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
+        error("API disabled in the current context", 2)
     end
 
     -- rc == FFI_ERROR
-    error(ffi_str(errmsg[0]))
+    error(ffi_str(errmsg[0]), 2)
 end
 
 
@@ -141,7 +141,7 @@ local function get_resp_header(tb, key)
     -- print("retval: ", n)
 
     if n == FFI_BAD_CONTEXT then
-        error("API disabled in the current context")
+        error("API disabled in the current context", 2)
     end
 
     if n == 0 then
@@ -163,7 +163,7 @@ local function get_resp_header(tb, key)
     end
 
     -- n == FFI_ERROR
-    error(ffi_str(errmsg[0]))
+    error(ffi_str(errmsg[0]), 2)
 end
 
 

--- a/lib/resty/core/shdict.lua
+++ b/lib/resty/core/shdict.lua
@@ -157,17 +157,17 @@ local errmsg = base.get_errmsg_ptr()
 
 local function check_zone(zone)
     if not zone or type(zone) ~= "table" then
-        error("bad \"zone\" argument", 2)
+        error("bad \"zone\" argument", 3)
     end
 
     zone = zone[1]
     if type(zone) ~= "userdata" then
-        error("bad \"zone\" argument", 2)
+        error("bad \"zone\" argument", 3)
     end
 
     zone = ngx_lua_ffi_shdict_udata_to_zone(zone)
     if zone == nil then
-        error("bad \"zone\" argument", 2)
+        error("bad \"zone\" argument", 3)
     end
 
     return zone

--- a/lib/resty/core/var.lua
+++ b/lib/resty/core/var.lua
@@ -70,7 +70,7 @@ local function var_get(self, name)
     end
 
     if rc == -1 then  -- NGX_ERROR
-        error(ffi_str(errmsg[0]))
+        error(ffi_str(errmsg[0]), 2)
     end
 end
 
@@ -111,7 +111,7 @@ local function var_set(self, name, value)
     end
 
     if rc == -1 then  -- NGX_ERROR
-        error(ffi_str(errbuf, errlen[0]))
+        error(ffi_str(errbuf, errlen[0]), 2)
     end
 end
 

--- a/t/shdict.t
+++ b/t/shdict.t
@@ -1611,11 +1611,11 @@ ttl: 2147483648
     }
 --- request
 GET /t
---- response_body_like
+--- response_body
 ok
-.+shdict\.lua:\d+: bad "zone" argument
-.+shdict\.lua:\d+: bad "zone" argument
-.+shdict\.lua:\d+: bad "zone" argument
+bad "zone" argument
+bad "zone" argument
+bad "zone" argument
 --- no_error_log
 [error]
 [alert]

--- a/t/stream/errlog-raw-log.t
+++ b/t/stream/errlog-raw-log.t
@@ -43,8 +43,8 @@ __DATA__
 
         ngx.say("ok")
     }
---- stream_response_like
-not ok: .*? bad log level
+--- stream_response
+not ok: bad log level
 --- no_error_log
 [error]
 
@@ -63,8 +63,8 @@ not ok: .*? bad log level
 
         ngx.say("ok")
     }
---- stream_response_like
-not ok: .*? bad log level
+--- stream_response
+not ok: bad log level
 --- no_error_log
 [error]
 

--- a/t/var.t
+++ b/t/var.t
@@ -205,8 +205,8 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):3 loop\]/
 --- request
 GET /test
 --- response_body_like
-.+/var\.lua:\d+: variable "foo" not found for writing; maybe it is a built-in variable that is not changeable or you forgot to use "set \$foo '';" in the config file to define it first
-.+/var\.lua:\d+: variable "server_port" not changeable
+content_by_lua\(nginx\.conf:\d+\):\d+: variable "foo" not found for writing; maybe it is a built-in variable that is not changeable or you forgot to use "set \$foo '';" in the config file to define it first
+content_by_lua\(nginx\.conf:\d+\):\d+: variable "server_port" not changeable
 --- no_error_log
 [error]
 [alert]


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

It is almost never useful for a user to see a stacktrace pointing to
lua-resty-core. Additionally, many ngx_http_lua test cases fail since
they expect stacktraces to point to specific Lua handlers.

This prevents stacktraces such as:

    runtime error: ../lua-resty-core/lib/resty/core/exit.lua:\d+: API disabled...

And instead ensures that stack traces look like:

    runtime error: content_by_lua(nginx.conf:\d+):\d+: API disabled...