### PR TITLE
regex: disable PCRE JIT compilation and regex cache in `init` phase w…

### DIFF
--- a/lib/resty/core/regex.lua
+++ b/lib/resty/core/regex.lua
@@ -30,6 +30,9 @@ local get_string_buf = base.get_string_buf
 local get_string_buf_size = base.get_string_buf_size
 local new_tab = base.new_tab
 local subsystem = ngx.config.subsystem
+local ngx_phase = ngx.get_phase
+local ngx_log = ngx.log
+local ngx_NOTICE = ngx.NOTICE
 
 
 if not ngx.re then
@@ -76,6 +79,25 @@ local ngx_lua_ffi_init_script_engine
 local ngx_lua_ffi_compile_replace_template
 local ngx_lua_ffi_script_eval_len
 local ngx_lua_ffi_script_eval_data
+-- PCRE 8.43 on macOS introduced the MAP_JIT option when creating memory region
+-- used to store JIT compiled code, which does not survive across `fork()`,
+-- causing further usage of PCRE JIT compiler to segfault in worker processes
+--
+-- this flag prevents any regex used in init phase to be JIT compiled or cached
+-- when running under macOS even if the user requests so. caching is disabled
+-- to prevent further calls of same regex in worker to have poor performance.
+local pcre_map_jit_fix = true
+
+
+local function get_pcre_map_jit_fix()
+    if not pcre_map_jit_fix then
+        return pcre_map_jit_fix
+    end
+
+    pcre_map_jit_fix = (jit.os == "OSX" and ngx_phase() == 'init')
+
+    return pcre_map_jit_fix
+end
 
 
 if subsystem == 'http' then
@@ -289,10 +311,22 @@ local function parse_regex_opts(opts)
     for i = 1, len do
         local opt = byte(opts, i)
         if opt == byte("o") then
-            flags = bor(flags, FLAG_COMPILE_ONCE)
+            if get_pcre_map_jit_fix() then
+                ngx_log(ngx_NOTICE, "running regex in init phase under macOS, ",
+                                    "compilation cache temporarily disabled")
+
+            else
+                flags = bor(flags, FLAG_COMPILE_ONCE)
+            end
 
         elseif opt == byte("j") then
-            flags = bor(flags, FLAG_JIT)
+            if get_pcre_map_jit_fix() then
+                ngx_log(ngx_NOTICE, "running regex in init phase under macOS, ",
+                                    "PCRE JIT compilation temporarily disabled")
+
+            else
+                flags = bor(flags, FLAG_JIT)
+            end
 
         elseif opt == byte("i") then
             pcre_opts = bor(pcre_opts, PCRE_CASELESS)

--- a/t/re-bug.t
+++ b/t/re-bug.t
@@ -1,0 +1,74 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 4);
+
+my $pwd = cwd();
+
+our $HttpConfig = <<_EOC_;
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
+    init_by_lua_block {
+        require "resty.core"
+        ngx.re.match('c', 'test', 'jo')
+    }
+_EOC_
+
+no_long_string();
+check_accum_error_log();
+run_tests();
+
+__DATA__
+
+=== TEST 1: PCRE MAP_JIT bug on macOS
+--- skip_eval
+4: $^O ne 'darwin'
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            ngx.say(ngx.re.sub('c', 'a', 'b', ''))
+            ngx.say(ngx.re.sub('c', 'a', 'b', 'jo'))
+            ngx.say("it works!")
+        }
+    }
+--- request
+    GET /re
+--- response_body
+c0
+c0
+it works!
+--- grep_error_log eval
+qr/.+parse_regex_opts\(\): running regex in init phase under macOS,.+/
+--- grep_error_log_out eval
+qr/(:?.+parse_regex_opts\(\): running regex in init phase under macOS,.+){2}/s
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: PCRE MAP_JIT bug fix does not affect other O/Ses
+--- skip_eval
+4: $^O ne 'linux'
+--- http_config eval: $::HttpConfig
+--- config
+    location /re {
+        content_by_lua_block {
+            ngx.say(ngx.re.sub('c', 'a', 'b', ''))
+            ngx.say(ngx.re.sub('c', 'a', 'b', 'jo'))
+            ngx.say("it works!")
+        }
+    }
+--- request
+    GET /re
+--- response_body
+c0
+c0
+it works!
+
+--- no_error_log
+[error]
+running regex in init phase under macOS

--- a/t/re-bugs.t
+++ b/t/re-bugs.t
@@ -55,7 +55,7 @@ qr/(:?.+parse_regex_opts\(\): running regex in init phase under macOS,.+){2}/s
 
 
 
-=== TEST 2: PCRE MAP_JIT bug fix does not affect other O/Ses
+=== TEST 2: PCRE MAP_JIT bug fix does not affect other OSes
 --- init_by_lua_block
     ngx.re.match('c', 'test', 'jo')
 --- skip_eval

--- a/t/re-bugs.t
+++ b/t/re-bugs.t
@@ -39,7 +39,6 @@ __DATA__
         content_by_lua_block {
             ngx.say(ngx.re.sub('c', 'a', 'b', ''))
             ngx.say(ngx.re.sub('c', 'a', 'b', 'jo'))
-            ngx.say("it works!")
         }
     }
 --- request
@@ -47,7 +46,6 @@ __DATA__
 --- response_body
 c0
 c0
-it works!
 --- grep_error_log eval
 qr/.+parse_regex_opts\(\): running regex in init phase under macOS,.+/
 --- grep_error_log_out eval
@@ -67,7 +65,6 @@ qr/(:?.+parse_regex_opts\(\): running regex in init phase under macOS,.+){2}/s
         content_by_lua_block {
             ngx.say(ngx.re.sub('c', 'a', 'b', ''))
             ngx.say(ngx.re.sub('c', 'a', 'b', 'jo'))
-            ngx.say("it works!")
         }
     }
 --- request
@@ -75,7 +72,6 @@ qr/(:?.+parse_regex_opts\(\): running regex in init phase under macOS,.+){2}/s
 --- response_body
 c0
 c0
-it works!
 --- no_error_log
 [error]
 running regex in init phase under macOS


### PR DESCRIPTION
…hen running on macOS.

On macOS Mojave and after, PCRE 8.43 applies the `MAP_JIT` flag to `mmap`ed region used to store PCRE JIT
compiled code. Unfortunately regions created this way does not survive across `fork()`
calls and will cause any further attempt to use the PCRE JIT compiler or execution
of JIT compiled regex to crash the worker immediately.

This patch work around that limitation by disabling PCRE JIT compiler and regex
cache when using regexes in the `init` phase. Note that the compilation cache has to
be disabled to avoid applications who uses the same regex in both `init` and later phases with
JIT turned on to suffer from bad runtime performance.

See:
* https://bugs.exim.org/show_bug.cgi?id=2334#c37
* https://github.com/mono/mono/issues/13445
* https://github.com/Kong/kong/issues/4471

# Performance implications
Disabling PCRE JIT in `init` phase only should pose minimum performance impact for majority of users. Since `init` phase usually does not perform a lot of this kind of operation. Furthermore the patch only affects macOS user, and does not cause any user perceivable changes.

# Minimum reproducible examples
See `t/re-bug.t` in this commit. Run it under macOS Mojave .using PCRE 8.43 without this PR and NGINX crashes.

Here is another example, with pure NGINX only to illustrate this problem: https://gist.github.com/dndx/dad77cd561f25c106a70fd8b26544a72

Just `curl 127.1:8080` to reproduce the problem.

# Next steps
Eventually we will be able to get rid of this commit once PCRE finally figures out how they want to allow user code to specify the usage of `MAP_JIT`. But I highly doubt it will happen that quickly. Due to the fact that they have not agreed on how the fix will work and slow release schedules (close to a year between 8.42 and 8.43). This PR is very much needed in the meantime.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
