### PR TITLE
bugfix: ndk: we should use the current request when the function is c…

### DIFF
--- a/lib/resty/core/ndk.lua
+++ b/lib/resty/core/ndk.lua
@@ -41,11 +41,6 @@ local ffi_str_type = ffi.typeof("ngx_http_lua_ffi_str_t*")
 
 
 local function ndk_set_var_get(self, var)
-    local r = get_request()
-    if not r then
-        error("no request found")
-    end
-
     if type(var) ~= "string" then
         var = tostring(var)
     end
@@ -58,6 +53,11 @@ local function ndk_set_var_get(self, var)
     local func = func_p[0]
 
     return function (arg)
+        local r = get_request()
+        if not r then
+            error("no request found")
+        end
+
         if type(arg) ~= "string" then
             arg = tostring(arg)
         end


### PR DESCRIPTION
…alled.

Also added the 'require "resty.core"' back which was removed in commit
bc713ce68431bdca0b00d5d9df0d4b0f277a6fb6 by accident.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
