### PR TITLE
optimize+bugfix: improved heuristics for the PCRE MAP_JIT workaround + support for binaries without PCRE

### DIFF
--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -16,7 +16,7 @@ local ffi_str = ffi.string
 local get_string_buf = base.get_string_buf
 local get_size_ptr = base.get_size_ptr
 local setmetatable = setmetatable
-local gsub = ngx.re.gsub
+local re = ngx.re
 local lower = string.lower
 local rawget = rawget
 local ngx = ngx
@@ -68,7 +68,7 @@ local truncated = ffi.new("int[1]")
 
 local req_headers_mt = {
     __index = function (tb, key)
-        return rawget(tb, (gsub(lower(key), '_', '-', "jo")))
+        return rawget(tb, (re.gsub(lower(key), '_', '-', "jo")))
     end
 }
 

--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -3,6 +3,8 @@
 
 local ffi = require 'ffi'
 local base = require "resty.core.base"
+base.allows_subsystem("http")
+local utils = require "resty.core.utils"
 
 
 local FFI_BAD_CONTEXT = base.FFI_BAD_CONTEXT
@@ -16,7 +18,6 @@ local ffi_str = ffi.string
 local get_string_buf = base.get_string_buf
 local get_size_ptr = base.get_size_ptr
 local setmetatable = setmetatable
-local re = ngx.re
 local lower = string.lower
 local rawget = rawget
 local ngx = ngx
@@ -25,6 +26,7 @@ local type = type
 local error = error
 local tostring = tostring
 local tonumber = tonumber
+local str_replace_char = utils.str_replace_char
 
 
 ffi.cdef[[
@@ -68,7 +70,7 @@ local truncated = ffi.new("int[1]")
 
 local req_headers_mt = {
     __index = function (tb, key)
-        return rawget(tb, (re.gsub(lower(key), '_', '-', "jo")))
+        return rawget(tb, (str_replace_char(lower(key), '_', '-')))
     end
 }
 

--- a/lib/resty/core/utils.lua
+++ b/lib/resty/core/utils.lua
@@ -1,0 +1,44 @@
+-- Copyright (C) Yichun Zhang (agentzh)
+
+
+local ffi = require "ffi"
+local base = require "resty.core.base"
+base.allows_subsystem("http")
+
+
+local C = ffi.C
+local ffi_str = ffi.string
+local ffi_copy = ffi.copy
+local byte = string.byte
+local str_find = string.find
+local get_string_buf = base.get_string_buf
+
+
+ffi.cdef[[
+    void ngx_http_lua_ffi_str_replace_char(unsigned char *buf, size_t len,
+        const unsigned char find, const unsigned char replace);
+]]
+
+
+local _M = {
+    version = base.version
+}
+
+
+function _M.str_replace_char(str, find, replace)
+    if not str_find(str, find, nil, true) then
+        return str
+    end
+
+    local len = #str
+    local buf = get_string_buf(len)
+    ffi_copy(buf, str)
+
+    C.ngx_http_lua_ffi_str_replace_char(buf, len, byte(find),
+                                        byte(replace))
+
+    return ffi_str(buf, len)
+end
+
+
+return _M

--- a/t/utils.t
+++ b/t/utils.t
@@ -1,0 +1,115 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib '.';
+use t::TestCore;
+
+plan tests => repeat_each() * blocks() * 3;
+
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    if (!defined $block->error_log) {
+        $block->set_value("no_error_log", "[error]");
+    }
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+no_diff();
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: utils.str_replace_char() sanity (replaces a single character)
+--- config
+    location /t {
+        content_by_lua_block {
+            local utils = require "resty.core.utils"
+
+            local strings = {
+                "Header_Name",
+                "_Header_Name_",
+                "Header__Name",
+                "Header-Name",
+                "Hello world",
+            }
+
+            for i = 1, #strings do
+                ngx.say(utils.str_replace_char(strings[i], "_", "-"))
+            end
+        }
+    }
+--- response_body
+Header-Name
+-Header-Name-
+Header--Name
+Header-Name
+Hello world
+
+
+
+=== TEST 2: utils.str_replace_char() JIT compiles when match
+--- config
+    location /t {
+        content_by_lua_block {
+            local utils = require "resty.core.utils"
+
+            for i = 1, $TEST_NGINX_HOTLOOP * 10 do
+                utils.str_replace_char("Header_Name", "_", "-")
+            end
+        }
+    }
+--- ignore_response_body
+--- error_log eval
+qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/,
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: utils.str_replace_char() JIT compiles when no match
+--- config
+    location /t {
+        content_by_lua_block {
+            local utils = require "resty.core.utils"
+
+            for i = 1, $TEST_NGINX_HOTLOOP * 10 do
+                utils.str_replace_char("Header_Name", "-", "_")
+            end
+        }
+    }
+--- ignore_response_body
+--- error_log eval
+qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/,
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: utils.str_replace_char() replacing more than one character is not supported
+--- config
+    location /t {
+        content_by_lua_block {
+            local utils = require "resty.core.utils"
+
+            local strings = {
+                "Header01Name",
+                "01Header01Name01",
+                "Header0Name",
+                "Header1Name",
+                "Hello world",
+            }
+
+            for i = 1, #strings do
+                ngx.say(utils.str_replace_char(strings[i], "02", "02"))
+            end
+        }
+    }
+--- response_body
+Header01Name
+01Header01Name01
+Header0Name
+Header1Name
+Hello world


### PR DESCRIPTION
> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

This is a follow up to d046562 which improves the heuristics to decide
whether PCRE JIT compilation should be disabled in init phase under
macOS or not. The heuristics now are:

- If under macOS
- If using PCRE 8.43 or greater
- Then PCRE JIT compilation will be disabled in the init phase

While PCRE JIT compilation is disabled as such, a notice log will notify
users attempting to use the `j` or `o` flags.

Once past the init phase, we revert the workaround and allow for the `j`
and `o` flags to be used, without any branching or additional
performance penalty.

New tests and minor refactorings have been included as well.

---

Also included: `bugfix: ensured resty.core can be loaded in binaries without PCRE support.`