### PR TITLE
bugfix: support calls to os.getenv wrapper even after unwrapping

### DIFF
--- a/lib/resty/core/misc.lua
+++ b/lib/resty/core/misc.lua
@@ -185,17 +185,22 @@ end
 
 
 do
+    local finished_wrapping_getenv = false
     local _getenv = os.getenv
     local env_ptr = ffi_new("unsigned char *[1]")
 
     os.getenv = function (name)
+        if finished_wrapping_getenv then
+            -- os.getenv is "unwrapped" but this function was called anyway
+            return _getenv(name)
+        end
         local r = get_request()
         if r then
             -- past init_by_lua* phase now
+            finished_wrapping_getenv = true
             os.getenv = _getenv
-            _getenv = nil
             env_ptr = nil
-            return os.getenv(name)
+            return _getenv(name)
         end
 
         local size = get_string_buf_size()


### PR DESCRIPTION
Fix a bug where the `os.getenv` wrapper function in misc.lua stops working after it "unwraps" and restores the original binding of `os.getenv`.

The wrapper function can still be referenced and called by a user and so we need to keep it working even after the original binding of `os.getenv` has been restored.

Consider this example:

    local getenv = os.getenv
    getenv("foo")
    getenv("bar")

which is problematic if *both* calls attempt to unwrap `os.getenv`.

Here is a real-world example that does trigger an error:
https://github.com/daurnimator/lua-http/blob/master/http/proxies.lua#L18-L32

I hereby granted the copyright of the changes in this pull request to the authors of this lua-resty-core project.
