### PR TITLE
bugfix: ensured 'os.getenv' can be localized before/after loading resty.core.

### DIFF
--- a/lib/resty/core/misc.lua
+++ b/lib/resty/core/misc.lua
@@ -193,7 +193,6 @@ do
         if r then
             -- past init_by_lua* phase now
             os.getenv = _getenv
-            _getenv = nil
             env_ptr = nil
             return os.getenv(name)
         end

--- a/t/os-getenv.t
+++ b/t/os-getenv.t
@@ -2,7 +2,7 @@
 use lib '.';
 use t::TestCore;
 
-plan tests => repeat_each() * (blocks() * 3);
+plan tests => repeat_each() * (blocks() * 3 + 2);
 
 add_block_preprocessor(sub {
     my $block = shift;
@@ -201,3 +201,94 @@ location /t {
 --- response_body
 in init: false
 in content: true
+
+
+
+=== TEST 9: os.getenv() can be localized before loading resty.core
+--- main_config
+env FOO=hello;
+--- http_config
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
+    lua_load_resty_core off;
+
+    init_by_lua_block {
+        package.loaded.os_getenv = os.getenv
+        require "resty.core"
+
+        do
+            local getenv = os.getenv
+
+            package.loaded.f = function ()
+                ngx.log(ngx.NOTICE, "FOO: ", getenv("FOO"))
+            end
+        end
+
+        package.loaded.f()
+
+        package.loaded.is_os_getenv = os.getenv == package.loaded.os_getenv
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        package.loaded.f()
+        package.loaded.f()
+
+        ngx.say("in init: ", package.loaded.is_os_getenv, "\n",
+                "in content: ", os.getenv == package.loaded.os_getenv)
+    }
+}
+--- response_body
+in init: false
+in content: true
+--- grep_error_log eval
+qr/FOO: [a-z]+/
+--- grep_error_log_out
+FOO: hello
+FOO: hello
+FOO: hello
+
+
+
+=== TEST 10: os.getenv() can be localized after loading resty.core
+--- main_config
+env FOO=hello;
+--- http_config
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
+    lua_load_resty_core off;
+
+    init_by_lua_block {
+        package.loaded.os_getenv = os.getenv
+
+        do
+            local getenv = os.getenv
+
+            package.loaded.f = function ()
+                ngx.log(ngx.NOTICE, "FOO: ", getenv("FOO"))
+            end
+        end
+
+        require "resty.core"
+
+        package.loaded.f()
+
+        package.loaded.is_os_getenv = os.getenv == package.loaded.os_getenv
+    }
+--- config
+location /t {
+    content_by_lua_block {
+        package.loaded.f()
+        package.loaded.f()
+
+        ngx.say("in init: ", package.loaded.is_os_getenv, "\n",
+                "in content: ", os.getenv == package.loaded.os_getenv)
+    }
+}
+--- response_body
+in init: false
+in content: false
+--- grep_error_log eval
+qr/FOO: [a-z]+/
+--- grep_error_log_out
+FOO: nil
+FOO: hello
+FOO: hello


### PR DESCRIPTION
Thanks Luke Gorrie for the report!

> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
