### PR TITLE
feature: ngx.re: ensured loading the module without PCRE produces a friendly error.

### DIFF
--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -8,6 +8,12 @@ local bit = require "bit"
 local core_regex = require "resty.core.regex"
 
 
+if core_regex.no_pcre then
+    error("no support for 'ngx.re' module: OpenResty was " ..
+          "compiled without PCRE support", 2)
+end
+
+
 local C = ffi.C
 local ffi_str = ffi.string
 local sub = string.sub

--- a/lib/resty/core/regex.lua
+++ b/lib/resty/core/regex.lua
@@ -60,6 +60,8 @@ if not pcall(function() pcre_ver = ffi_string(C.pcre_version()) end) then
         end
     })
 
+    _M.no_pcre = true
+
     return _M
 end
 

--- a/t/re-split.t
+++ b/t/re-split.t
@@ -1246,3 +1246,28 @@ GET /re
 qr/\[TRACE\s+\d+/
 --- no_error_log
 [error]
+
+
+
+=== TEST 40: cannot load ngx.re module when lacking PCRE support
+--- config
+    location /re {
+        content_by_lua_block {
+            package.loaded["ngx.re"] = nil
+
+            local core_regex = require "resty.core.regex"
+            core_regex.no_pcre = true
+
+            local pok, perr = pcall(require, "ngx.re")
+            if not pok then
+                ngx.say(perr)
+            end
+        }
+    }
+--- request
+GET /re
+--- response_body
+no support for 'ngx.re' module: OpenResty was compiled without PCRE support
+--- no_error_log
+[error]
+[crit]


### PR DESCRIPTION
I considered various alternatives in implementations and testing, but went with a straightforward approach for now.

> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

