### PR TITLE
bugfix: ngx.re: fixed the error stacktrace level when missing PCRE support.

### DIFF
--- a/lib/ngx/re.lua
+++ b/lib/ngx/re.lua
@@ -10,7 +10,7 @@ local core_regex = require "resty.core.regex"
 
 if core_regex.no_pcre then
     error("no support for 'ngx.re' module: OpenResty was " ..
-          "compiled without PCRE support", 2)
+          "compiled without PCRE support", 3)
 end
 
 


### PR DESCRIPTION
Since we override the `require` function in `resty.base`, the proper
stacktrace level for this error is 3 since it is thrown in the main
chunk of the module.

Example:

Previously, the previous behavior with `resty` was:

    $ resty -e 'require "ngx.re"'
    ERROR: no support for 'ngx.re' module: OpenResty was compiled without PCRE support
    stack traceback:
            ...

Now, the error contains the chunkame `(command line -e):1:`:

    $ resty -e 'require "ngx.re"'
    ERROR: (command line -e):1: no support for 'ngx.re' module: OpenResty was compiled without PCRE support
    stack traceback:
            ...

Which is similar to the error reported by other `ngx.re` APIs when
attempting to use them without PCRE support:

    $ resty -e 'ngx.re.gmatch()'
    ERROR: (command line -e):1: no support for 'ngx.re.gmatch': OpenResty was compiled without PCRE support
    stack traceback:
            ...

Sister PR:
- https://github.com/openresty/lua-nginx-module/pull/1584

No tests for this change at the moment, as our test matrix does not include a build without PCRE support, which is something I will work on in the future, after revisiting the CI setup.

> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.