### PR TITLE
feature: add support for exporting key material to derive keys from t…

### DIFF
--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -330,7 +330,7 @@ export_keying_material
 ----------------------
 **syntax:** *key, err = ssl.export_keying_material(length, label, context)*
 
-context: *any*
+context: *set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
 
 Return a key derived from the SSL master secret.
 
@@ -365,7 +365,7 @@ export_keying_material_early
 ----------------------------
 **syntax:** *key, err = ssl.export_keying_material_early(length, label, context)*
 
-context: *any*
+context: *set_by_lua&#42;, rewrite_by_lua&#42;, access_by_lua&#42;, content_by_lua&#42;, header_filter_by_lua&#42;, body_filter_by_lua&#42;, log_by_lua&#42;*
 
 Returns a key derived from the SSL early exporter master secret.
 

--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -30,6 +30,8 @@ Table of Contents
     * [set_priv_key](#set_priv_key)
     * [verify_client](#verify_client)
     * [get_client_random](#get_client_random)
+    * [export_keying_material](#export_keying_material)
+    * [export_keying_material_early](#export_keying_material_early)
 * [Community](#community)
     * [English Mailing List](#english-mailing-list)
     * [Chinese Mailing List](#chinese-mailing-list)
@@ -323,6 +325,76 @@ end
 This function can be called in any context where downstream https is used.
 
 [Back to TOC](#table-of-contents)
+
+export_keying_material
+----------------------
+**syntax:** *key, err = ssl.export_keying_material(length, label, context)*
+
+context: *any*
+
+Return a key derived from the SSL master secret.
+
+As described in RFC8446 section 7.5 this function returns key material that is derived from the SSL master secret and can be used on the application level. The returned key material is of the given length. Label is mandatory and requires a special format that is described in RFC5705 section 4. Context is optional but note that in TLSv1.2 and below a zero length context is treated differently from no context at all, and will result in different keying material being returned. In TLSv1.3 a zero length context is that same as no context at all and will result in the same keying material being returned.
+
+The following code snippet shows how to derive a new key that can be used on the application level.
+
+```lua
+local ssl = require "ngx.ssl"
+
+local key_length = 16
+local label = "EXPERIMENTAL my label"
+local context = "\x00\x01\x02\x03"
+
+local key, err = ssl.export_keying_material(key_length, label, context)
+if not key then
+    ngx.log(ngx.ERR, "failed to derive key ", err)
+    return
+end
+
+-- use key...
+
+end
+```
+
+This function can be called in any context where downstream https is used.
+
+[Back to TOC](#table-of-contents)
+
+
+export_keying_material_early
+----------------------------
+**syntax:** *key, err = ssl.export_keying_material_early(length, label, context)*
+
+context: *any*
+
+Returns a key derived from the SSL early exporter master secret.
+
+As described in RFC8446 section 7.5 this function returns key material that is derived from the SSL early exporter master secret and can be used on the application level. The returned key material is of the given length. Label is mandatory and requires a special format that is described in RFC5705 section 4. This function is only usable with TLSv1.3, and derives keying material using the early_exporter_master_secret (as defined in the TLS 1.3 RFC). For the client, the early_exporter_master_secret is only available when the client attempts to send 0-RTT data. For the server, it is only available when the server accepts 0-RTT data.
+
+The following code snippet shows how to derive a new key that can be used on the application level.
+
+```lua
+local ssl = require "ngx.ssl"
+
+local key_length = 16
+local label = "EXPERIMENTAL my label"
+local context = "\x00\x01\x02\x03"
+
+local key, err = ssl.export_keying_material_early(key_length, label, context)
+if not key then
+    ngx.log(ngx.ERR, "failed to derive key ", err)
+    return
+end
+
+-- use key...
+
+end
+```
+
+This function can be called in any context where downstream https TLS1.3 is used.
+
+[Back to TOC](#table-of-contents)
+
 
 raw_client_addr
 ---------------

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -3076,3 +3076,110 @@ client-random length: 32
 [error]
 [alert]
 [emerg]
+
+
+
+
+=== TEST 31: export_keying_material
+--- http_config
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate_by_lua_block {
+            local ssl = require "ngx.ssl"
+            local client_random_len = ssl.get_client_random(0)
+            print("client-random length: ", client_random_len)
+
+            local init_v = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+            local client_random = ssl.get_client_random()
+            if client_random == init_v then
+                print("maybe the client random value is incorrect")
+            end
+        }
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {ngx.status = 201 ngx.say("foo") ngx.exit(201)}
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(3000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: cdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received: 
+received: foo
+close: 1 nil
+
+--- error_log
+client-random length: 32
+
+--- no_error_log
+[error]
+[alert]
+[emerg]

--- a/t/stream/ssl.t
+++ b/t/stream/ssl.t
@@ -2142,6 +2142,7 @@ lua ssl server name: "test.com"
 [emerg]
 
 
+
 === TEST 27: parse DER cert and key to cdata
 --- stream_config
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request to the authors of this lua-resty-core project.

TLS has the support to derive key material from the TLS master secret that can be used on the application level. This is described in RFC8446 section 7-5. OpenSSL offers support for this [here](https://www.openssl.org/docs/man1.1.1/man3/SSL_export_keying_material.html).

We would like to use these functions from lua. This PR extends the ssl module for that. It depends on https://github.com/openresty/lua-nginx-module/pull/1591.
