### PR TITLE
optimize: moved 'resty.core.misc' to be loaded last to avoid metatable lookups on 'ngx'.

### DIFF
--- a/lib/resty/core.lua
+++ b/lib/resty/core.lua
@@ -3,13 +3,11 @@
 local subsystem = ngx.config.subsystem
 
 
-require "resty.core.ctx"
 require "resty.core.var"
 require "resty.core.worker"
 require "resty.core.regex"
 require "resty.core.shdict"
 require "resty.core.time"
-require "resty.core.misc"
 require "resty.core.hash"
 require "resty.core.uri"
 require "resty.core.exit"
@@ -22,6 +20,10 @@ if subsystem == 'http' then
     require "resty.core.phase"
     require "resty.core.ndk"
 end
+
+
+require "resty.core.misc"
+require "resty.core.ctx"
 
 
 local base = require "resty.core.base"

--- a/lib/resty/core/shdict.lua
+++ b/lib/resty/core/shdict.lua
@@ -62,7 +62,7 @@ int ngx_http_lua_ffi_shdict_store(void *zone, int op,
 int ngx_http_lua_ffi_shdict_flush_all(void *zone);
 
 long ngx_http_lua_ffi_shdict_get_ttl(void *zone,
-     const unsigned char *key, size_t key_len);
+    const unsigned char *key, size_t key_len);
 
 int ngx_http_lua_ffi_shdict_set_expire(void *zone,
     const unsigned char *key, size_t key_len, long exptime);


### PR DESCRIPTION
This ensures that all `resty.core` modules setting values under the
`ngx` table can do so without having to enter the `__newindex`
metamethod set by `resty.core.misc`. This commit also includes a style
fix.

> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
