### PR TITLE
feature: implement `ssl.verify_client()`

### DIFF
--- a/lib/ngx/ssl.lua
+++ b/lib/ngx/ssl.lua
@@ -81,7 +81,7 @@ if subsystem == 'http' then
     void ngx_http_lua_ffi_free_priv_key(void *cdata);
 
     int ngx_http_lua_ffi_ssl_verify_client(void *r,
-        int depth, void *cdata, char **err);
+        void *cdata, int depth, char **err);
     ]]
 
     ngx_lua_ffi_ssl_set_der_certificate =
@@ -147,7 +147,7 @@ elseif subsystem == 'stream' then
     void ngx_stream_lua_ffi_free_priv_key(void *cdata);
 
     int ngx_stream_lua_ffi_ssl_verify_client(void *r,
-        int depth, void *cdata, char **err);
+        void *cdata, int depth, char **err);
     ]]
 
     ngx_lua_ffi_ssl_set_der_certificate =
@@ -389,13 +389,17 @@ function _M.set_priv_key(priv_key)
 end
 
 
-function _M.verify_client(depth, ca_certs)
+function _M.verify_client(ca_certs, depth)
     local r = get_request()
     if not r then
         error("no request found")
     end
 
-    local rc = ngx_lua_ffi_ssl_verify_client(r, depth, ca_certs, errmsg)
+    if not depth then
+        depth = -1
+    end
+
+    local rc = ngx_lua_ffi_ssl_verify_client(r, ca_certs, depth, errmsg)
     if rc == FFI_OK then
         return true
     end

--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -496,7 +496,7 @@ Returns `true` on success, or a `nil` value and a string describing the error ot
 Note that TLS is not terminated when verification fails. You need to examine Nginx variable `$ssl_client_verify`
 later to determine next steps.
 
-This function was first added in version `0.1.18`.
+This function was first added in version `0.1.20`.
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -477,16 +477,19 @@ This function was first added in version `0.1.7`.
 
 verify_client
 ------------
-**syntax:** *ok, err = ssl.verify_client(depth, ca_certs)*
+**syntax:** *ok, err = ssl.verify_client(ca_certs?, depth?)*
 
 **context:** *ssl_certificate_by_lua&#42;*
 
 Requires a client certificate during TLS handshake.
 
-The `depth` is the verification depth in the client certificates chain.
-
 The `ca_certs` is the CA certificate chain opaque pointer returned by the
 [parse_pem_cert](#parse_pem_cert) function for the current SSL connection.
+The list of certificates will be sent to clients. Also, they will be added to trusted store.
+If omitted, will not send any CA certificate to clients.
+
+The `depth` is the verification depth in the client certificates chain.
+If omitted, will use the value specified by `ssl_verify_depth`.
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
 

--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -475,6 +475,28 @@ This function was first added in version `0.1.7`.
 
 [Back to TOC](#table-of-contents)
 
+verify_client
+------------
+**syntax:** *ok, err = ssl.verify_client(depth, ca_certs)*
+
+**context:** *ssl_certificate_by_lua&#42;*
+
+Requires a client certificate during TLS handshake.
+
+The `depth` is the verification depth in the client certificates chain.
+
+The `ca_certs` is the CA certificate chain opaque pointer returned by the
+[parse_pem_cert](#parse_pem_cert) function for the current SSL connection.
+
+Returns `true` on success, or a `nil` value and a string describing the error otherwise.
+
+Note that TLS is not terminated when verification fails. You need to examine Nginx variable `$ssl_client_verify`
+later to determine next steps.
+
+This function was first added in version `0.1.18`.
+
+[Back to TOC](#table-of-contents)
+
 Community
 =========
 

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -2353,7 +2353,7 @@ got TLS1 version: TLSv1.3,
                 return
             end
 
-            local ok, err = ssl.verify_client(1, cert)
+            local ok, err = ssl.verify_client(cert, 1)
             if not ok then
                 ngx.log(ngx.ERR, "failed to verify client: ", err)
                 return
@@ -2408,7 +2408,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ok, err = ssl.verify_client(1, nil)
+            local ok, err = ssl.verify_client()
             if not ok then
                 ngx.log(ngx.ERR, "failed to verify client: ", err)
                 return
@@ -2463,7 +2463,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ok, err = ssl.verify_client(1, nil)
+            local ok, err = ssl.verify_client()
             if not ok then
                 ngx.log(ngx.ERR, "failed to verify client: ", err)
                 return

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -2377,6 +2377,7 @@ got TLS1 version: TLSv1.3,
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
         proxy_ssl_certificate       ../../cert/test.crt;
         proxy_ssl_certificate_key   ../../cert/test.key;
+        proxy_ssl_session_reuse     off;
     }
 
 --- request
@@ -2428,6 +2429,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
         proxy_ssl_certificate       ../../cert/test.crt;
         proxy_ssl_certificate_key   ../../cert/test.key;
+        proxy_ssl_session_reuse     off;
     }
 
 --- request
@@ -2487,6 +2489,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
 --- config
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_ssl_session_reuse     off;
     }
 
 --- request

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -2360,8 +2360,8 @@ got TLS1 version: TLSv1.3,
             end
         }
 
-        ssl_certificate ../../cert/test.crt;
-        ssl_certificate_key ../../cert/test.key;
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
 
         server_tokens off;
         location / {
@@ -2375,7 +2375,7 @@ got TLS1 version: TLSv1.3,
     }
 --- config
     server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
@@ -2415,8 +2415,8 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
             end
         }
 
-        ssl_certificate ../../cert/test.crt;
-        ssl_certificate_key ../../cert/test.key;
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
 
         server_tokens off;
         location / {
@@ -2430,7 +2430,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
     }
 --- config
     server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
@@ -2470,8 +2470,8 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
             end
         }
 
-        ssl_certificate ../../cert/test.crt;
-        ssl_certificate_key ../../cert/test.key;
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
 
         server_tokens off;
         location / {
@@ -2485,7 +2485,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
     }
 --- config
     server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -2363,7 +2363,6 @@ got TLS1 version: TLSv1.3,
         ssl_certificate ../../cert/test2.crt;
         ssl_certificate_key ../../cert/test2.key;
 
-        server_tokens off;
         location / {
             default_type 'text/plain';
             content_by_lua_block {
@@ -2374,9 +2373,6 @@ got TLS1 version: TLSv1.3,
         }
     }
 --- config
-    server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test2.crt;
-
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
         proxy_ssl_certificate       ../../cert/test.crt;
@@ -2418,7 +2414,6 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         ssl_certificate ../../cert/test2.crt;
         ssl_certificate_key ../../cert/test2.key;
 
-        server_tokens off;
         location / {
             default_type 'text/plain';
             content_by_lua_block {
@@ -2429,9 +2424,6 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         }
     }
 --- config
-    server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test2.crt;
-
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
         proxy_ssl_certificate       ../../cert/test.crt;
@@ -2463,7 +2455,17 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ok, err = ssl.verify_client()
+            local f = assert(io.open("t/cert/test.crt"))
+            local cert_data = f:read("*a")
+            f:close()
+
+            local cert, err = ssl.parse_pem_cert(cert_data)
+            if not cert then
+                ngx.log(ngx.ERR, "failed to parse pem cert: ", err)
+                return
+            end
+
+            local ok, err = ssl.verify_client(cert, 1)
             if not ok then
                 ngx.log(ngx.ERR, "failed to verify client: ", err)
                 return
@@ -2473,7 +2475,6 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         ssl_certificate ../../cert/test2.crt;
         ssl_certificate_key ../../cert/test2.key;
 
-        server_tokens off;
         location / {
             default_type 'text/plain';
             content_by_lua_block {
@@ -2484,9 +2485,6 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         }
     }
 --- config
-    server_tokens off;
-    lua_ssl_trusted_certificate ../../cert/test2.crt;
-
     location /t {
         proxy_pass                  https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     }

--- a/t/stream/ssl.t
+++ b/t/stream/ssl.t
@@ -1924,7 +1924,7 @@ got TLS1 version: TLSv1.3,
         }
     }
 --- stream_server_config
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     proxy_pass                  unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl                   on;
@@ -1968,7 +1968,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         }
     }
 --- stream_server_config
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     proxy_pass                  unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl                   on;
@@ -2012,7 +2012,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         }
     }
 --- stream_server_config
-    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_trusted_certificate ../../cert/test2.crt;
 
     proxy_pass                  unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl                   on;

--- a/t/stream/ssl.t
+++ b/t/stream/ssl.t
@@ -1928,6 +1928,7 @@ got TLS1 version: TLSv1.3,
     proxy_ssl                   on;
     proxy_ssl_certificate       ../../cert/test.crt;
     proxy_ssl_certificate_key   ../../cert/test.key;
+    proxy_ssl_session_reuse     off;
 
 --- stream_response
 SUCCESS
@@ -1970,6 +1971,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
     proxy_ssl                   on;
     proxy_ssl_certificate       ../../cert/test.crt;
     proxy_ssl_certificate_key   ../../cert/test.key;
+    proxy_ssl_session_reuse     off;
 
 --- stream_response
 FAILED:self signed certificate
@@ -2020,6 +2022,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
 --- stream_server_config
     proxy_pass                  unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl                   on;
+    proxy_ssl_session_reuse     off;
 
 --- stream_response
 NONE

--- a/t/stream/ssl.t
+++ b/t/stream/ssl.t
@@ -1911,7 +1911,7 @@ got TLS1 version: TLSv1.3,
                 return
             end
 
-            local ok, err = ssl.verify_client(1, cert)
+            local ok, err = ssl.verify_client(cert, 1)
             if not ok then
                 ngx.log(ngx.ERR, "failed to verify client: ", err)
                 return
@@ -1955,7 +1955,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ok, err = ssl.verify_client(1, nil)
+            local ok, err = ssl.verify_client()
             if not ok then
                 ngx.log(ngx.ERR, "failed to verify client: ", err)
                 return
@@ -1999,7 +1999,7 @@ client certificate subject: emailAddress=agentzh@gmail.com,CN=test.com
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ok, err = ssl.verify_client(1, nil)
+            local ok, err = ssl.verify_client()
             if not ok then
                 ngx.log(ngx.ERR, "failed to verify client: ", err)
                 return


### PR DESCRIPTION
This PR adds an API that allows users to configure SSL client certificate verification dynamically. For example, Nginx can now read SNI first and then determine whether to request a client certificate during handshake. Optionally, caller can pass in a CA list used for verification.

See https://github.com/openresty/lua-nginx-module/pull/1666 for FFI changes.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.