### PR TITLE
ngx.req.get_headers return empty table with metatable

### DIFF
--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -109,7 +109,12 @@ function ngx.req.get_headers(max_headers, raw)
     end
 
     if n == 0 then
-        return {}
+        local headers = {}
+        if raw == 0 then
+            headers = setmetatable(headers, req_headers_mt)
+        end
+
+        return headers
     end
 
     local raw_buf = get_string_buf(n * table_elt_size)

--- a/t/request.t
+++ b/t/request.t
@@ -564,16 +564,14 @@ Foo: baz, 123
             end
             ngx.log(ngx.ERR, "headers type:", type(headers))
             ngx.log(ngx.ERR, "headers metatable type:", type(getmetatable(headers)))
-            ngx.say(type(headers))
-            ngx.say(type(getmetatable(headers)))
+            ngx.say(string.format("%s,%s",type(headers), type(getmetatable(headers))))
         }
     }
 
 --- raw_request eval
 "GET /t\r\n"
 --- response_body
-table
-table
+table,table
 --- http09
 --- error_code
 200

--- a/t/request.t
+++ b/t/request.t
@@ -8,7 +8,7 @@ use t::TestCore;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 5 + 4);
+plan tests => repeat_each() * (blocks() * 5 + 5);
 
 #no_diff();
 #no_long_string();

--- a/t/request.t
+++ b/t/request.t
@@ -212,7 +212,7 @@ GET /t?a=3%200&foo%20bar=&a=hello&blah
 --- response_body
 a: 3 0, hello
 blah: true
-foo bar: 
+foo bar:
 --- error_log eval
 qr/\[TRACE\s+\d+ .*? -> \d+\]/
 --- no_error_log
@@ -553,3 +553,27 @@ Foo: bar
 Foo: baz, 123
 --- no_error_log
 [error]
+
+=== TEST 18: ngx.req.get_header (metatable is nil)
+--- config
+    location = /t {
+        content_by_lua_block {
+            local headers = ngx.req.get_headers()
+            for k, v in pairs(headers) do
+                ngx.log(ngx.ERR, "headers: ", k, v)
+            end
+            ngx.log(ngx.ERR, "headers type:", type(headers))
+            ngx.log(ngx.ERR, "headers metatable type:", type(getmetatable(headers)))
+            ngx.say(type(headers))
+            ngx.say(type(getmetatable(headers)))
+        }
+    }
+
+--- raw_request eval
+"GET /metatable\r\n"
+--- response_body
+table
+talbe
+--- http09
+--- error_code
+200

--- a/t/request.t
+++ b/t/request.t
@@ -212,7 +212,7 @@ GET /t?a=3%200&foo%20bar=&a=hello&blah
 --- response_body
 a: 3 0, hello
 blah: true
-foo bar:
+foo bar: 
 --- error_log eval
 qr/\[TRACE\s+\d+ .*? -> \d+\]/
 --- no_error_log

--- a/t/request.t
+++ b/t/request.t
@@ -570,7 +570,7 @@ Foo: baz, 123
     }
 
 --- raw_request eval
-"GET /metatable\r\n"
+"GET /t\r\n"
 --- response_body
 table
 talbe

--- a/t/request.t
+++ b/t/request.t
@@ -559,19 +559,13 @@ Foo: baz, 123
     location = /t {
         content_by_lua_block {
             local headers = ngx.req.get_headers()
-            for k, v in pairs(headers) do
-                ngx.log(ngx.ERR, "headers: ", k, v)
-            end
-            ngx.log(ngx.ERR, "headers type:", type(headers))
-            ngx.log(ngx.ERR, "headers metatable type:", type(getmetatable(headers)))
+
             ngx.say(string.format("%s,%s",type(headers), type(getmetatable(headers))))
         }
     }
 
 --- raw_request eval
-"GET /t\r\n"
+"GET /t \r\n"
+--- http09
 --- response_body
 table,table
---- http09
---- error_code
-200

--- a/t/request.t
+++ b/t/request.t
@@ -554,8 +554,6 @@ Foo: baz, 123
 --- no_error_log
 [error]
 
-
-
 === TEST 18: ngx.req.get_header (metatable is nil)
 --- config
     location = /t {

--- a/t/request.t
+++ b/t/request.t
@@ -8,7 +8,7 @@ use t::TestCore;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 5 + 8);
+plan tests => repeat_each() * (blocks() * 5 + 4);
 
 #no_diff();
 #no_long_string();

--- a/t/request.t
+++ b/t/request.t
@@ -554,6 +554,8 @@ Foo: baz, 123
 --- no_error_log
 [error]
 
+
+
 === TEST 18: ngx.req.get_header (metatable is nil)
 --- config
     location = /t {

--- a/t/request.t
+++ b/t/request.t
@@ -571,5 +571,3 @@ Foo: baz, 123
 --- http09
 --- response_body
 table,table
-
---- no_error_log

--- a/t/request.t
+++ b/t/request.t
@@ -573,7 +573,7 @@ Foo: baz, 123
 "GET /t\r\n"
 --- response_body
 table
-talbe
+table
 --- http09
 --- error_code
 200

--- a/t/request.t
+++ b/t/request.t
@@ -571,3 +571,5 @@ Foo: baz, 123
 --- http09
 --- response_body
 table,table
+
+--- no_error_log


### PR DESCRIPTION
when one request has none header,  use ngx.req.get_headers will get an empty table without metatable. i think ngx.req.get_headers shuld return `nil` or table with metatable. 