### PR TITLE
feature: add the `balancer.recreate_request` function, which allows user to recreate request buffer in balancer phase.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b proxy_recreate_request https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone -b proxy_recreate_request https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git

--- a/lib/ngx/balancer.lua
+++ b/lib/ngx/balancer.lua
@@ -38,6 +38,10 @@ if subsystem == 'http' then
     int ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
         long connect_timeout, long send_timeout,
         long read_timeout, char **err);
+
+    int
+    ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
+        char **err);
     ]]
 
     ngx_lua_ffi_balancer_set_current_peer =
@@ -204,6 +208,27 @@ function _M.set_timeouts(connect_timeout, send_timeout, read_timeout)
     end
 
     return false, ffi_str(errmsg[0])
+end
+
+
+if subsystem == 'http' then
+    function _M.recreate_request()
+        local r = get_request()
+        if not r then
+            error("no request found")
+        end
+
+        local rc = C.ngx_http_lua_ffi_balancer_recreate_request(r, errmsg)
+        if rc == FFI_OK then
+            return true
+        end
+
+        if errmsg[0] ~= nil then
+            return nil, ffi_str(errmsg[0])
+        end
+
+        return nil, "failed to recreate the upstream request"
+    end
 end
 
 

--- a/lib/ngx/balancer.lua
+++ b/lib/ngx/balancer.lua
@@ -39,8 +39,7 @@ if subsystem == 'http' then
         long connect_timeout, long send_timeout,
         long read_timeout, char **err);
 
-    int
-    ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
+    int ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
         char **err);
     ]]
 

--- a/lib/ngx/balancer.md
+++ b/lib/ngx/balancer.md
@@ -237,6 +237,29 @@ This function was first added in the `0.1.7` version of this library.
 
 [Back to TOC](#table-of-contents)
 
+recreate_request
+------------
+**syntax:** `ok, err = balancer.recreate_request()`
+
+**context:** *balancer_by_lua&#42;*
+
+Regenerates the request buffer for sending to the upstream server. This is useful, for example
+if you want to change a request header field to the new upstream server on balancer retries.
+
+Normally this does not work because the request buffer is created once during upstream module
+initialization and won't be regenerated for subsequent retries. However you can use
+`proxy_set_header My-Header $my_header` and sets the `ngx.var.my_header` variable inside the
+balancer phase. Calling this function after that will cause the request buffer to be re-generated
+and the `My-Header` header will thus contain the new value.
+
+**Warning:** because the request buffer has to be recreated and such allocation occurs on the
+request memory pool, the old buffer has to be thrown away and only be freed after the request
+finishes. Do not call this function too often or memory leaks may be noticeable. Even so, a call
+to this function should be made **only** if you know the request buffer must be regenerated,
+instead of unconditionally in each balancer retries.
+
+This function was first added in the `0.1.19` version of this library.
+
 Community
 =========
 

--- a/lib/ngx/balancer.md
+++ b/lib/ngx/balancer.md
@@ -9,12 +9,15 @@ Table of Contents
 * [Name](#name)
 * [Status](#status)
 * [Synopsis](#synopsis)
+    * [http subsystem](#http-subsystem)
+    * [stream subsystem](#stream-subsystem)
 * [Description](#description)
 * [Methods](#methods)
     * [set_current_peer](#set_current_peer)
     * [set_more_tries](#set_more_tries)
     * [get_last_failure](#get_last_failure)
     * [set_timeouts](#set_timeouts)
+    * [recreate_request](#recreate_request)
 * [Community](#community)
     * [English Mailing List](#english-mailing-list)
     * [Chinese Mailing List](#chinese-mailing-list)
@@ -79,6 +82,8 @@ http {
 }
 ```
 
+[Back to TOC](#table-of-contents)
+
 stream subsystem
 ----------------
 
@@ -120,6 +125,8 @@ stream {
     }
 }
 ```
+
+[Back to TOC](#table-of-contents)
 
 Description
 ===========
@@ -238,27 +245,30 @@ This function was first added in the `0.1.7` version of this library.
 [Back to TOC](#table-of-contents)
 
 recreate_request
-------------
+----------------
 **syntax:** `ok, err = balancer.recreate_request()`
 
 **context:** *balancer_by_lua&#42;*
 
-Regenerates the request buffer for sending to the upstream server. This is useful, for example
+Recreates the request buffer for sending to the upstream server. This is useful, for example
 if you want to change a request header field to the new upstream server on balancer retries.
 
 Normally this does not work because the request buffer is created once during upstream module
 initialization and won't be regenerated for subsequent retries. However you can use
-`proxy_set_header My-Header $my_header` and sets the `ngx.var.my_header` variable inside the
-balancer phase. Calling this function after that will cause the request buffer to be re-generated
-and the `My-Header` header will thus contain the new value.
+`proxy_set_header My-Header $my_header` and set the `ngx.var.my_header` variable inside the
+balancer phase. Calling `balancer.recreate_request()` after updating a header field will
+cause the request buffer to be re-generated and the `My-Header` header will thus contain
+the new value.
 
 **Warning:** because the request buffer has to be recreated and such allocation occurs on the
-request memory pool, the old buffer has to be thrown away and only be freed after the request
+request memory pool, the old buffer has to be thrown away and will only be freed after the request
 finishes. Do not call this function too often or memory leaks may be noticeable. Even so, a call
 to this function should be made **only** if you know the request buffer must be regenerated,
 instead of unconditionally in each balancer retries.
 
 This function was first added in the `0.1.19` version of this library.
+
+[Back to TOC](#table-of-contents)
 
 Community
 =========

--- a/lib/ngx/balancer.md
+++ b/lib/ngx/balancer.md
@@ -266,7 +266,7 @@ finishes. Do not call this function too often or memory leaks may be noticeable.
 to this function should be made **only** if you know the request buffer must be regenerated,
 instead of unconditionally in each balancer retries.
 
-This function was first added in the `0.1.19` version of this library.
+This function was first added in the `0.1.20` version of this library.
 
 [Back to TOC](#table-of-contents)
 

--- a/t/balancer.t
+++ b/t/balancer.t
@@ -848,13 +848,13 @@ GET /t
             print("here")
             local b = require "ngx.balancer"
 
-            if ngx.ctx.balancer_ran then
+            if ngx.ctx.balancer_run then
                 assert(b.set_current_peer("127.0.0.1", tonumber(ngx.var.server_port)))
                 ngx.var.test = "second"
                 assert(b.recreate_request())
 
             else
-                ngx.ctx.balancer_ran = true
+                ngx.ctx.balancer_run = true
                 assert(b.set_current_peer("127.0.0.3", 12345))
                 assert(b.set_more_tries(1))
             end


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

Feature was originally developed by @locao inside https://github.com/Kong/lua-kong-nginx-module/pull/13. With slight modifications from @dndx.

Related PR: https://github.com/openresty/lua-nginx-module/pull/1734.