### PR TITLE
bugfix: added the missing 'ngx.req.start_time' to the stream subsystem.

### DIFF
--- a/lib/resty/core.lua
+++ b/lib/resty/core.lua
@@ -12,10 +12,10 @@ require "resty.core.hash"
 require "resty.core.uri"
 require "resty.core.exit"
 require "resty.core.base64"
+require "resty.core.request"
 
 
 if subsystem == 'http' then
-    require "resty.core.request"
     require "resty.core.response"
     require "resty.core.phase"
     require "resty.core.ndk"

--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -3,10 +3,10 @@
 
 local ffi = require 'ffi'
 local base = require "resty.core.base"
-base.allows_subsystem("http")
 local utils = require "resty.core.utils"
 
 
+local subsystem = ngx.config.subsystem
 local FFI_BAD_CONTEXT = base.FFI_BAD_CONTEXT
 local FFI_DECLINED = base.FFI_DECLINED
 local FFI_OK = base.FFI_OK
@@ -34,6 +34,40 @@ local _M = {
 }
 
 
+local ngx_lua_ffi_req_start_time
+
+
+if subsystem == "stream" then
+    ffi.cdef[[
+    double ngx_stream_lua_ffi_req_start_time(ngx_stream_lua_request_t *r);
+    ]]
+
+    ngx_lua_ffi_req_start_time = C.ngx_stream_lua_ffi_req_start_time
+
+elseif subsystem == "http" then
+    ffi.cdef[[
+    double ngx_http_lua_ffi_req_start_time(ngx_http_request_t *r);
+    ]]
+
+    ngx_lua_ffi_req_start_time = C.ngx_http_lua_ffi_req_start_time
+end
+
+
+function ngx.req.start_time()
+    local r = get_request()
+    if not r then
+        error("no request found")
+    end
+
+    return tonumber(ngx_lua_ffi_req_start_time(r))
+end
+
+
+if subsystem == "stream" then
+    return _M
+end
+
+
 local errmsg = base.get_errmsg_ptr()
 local ffi_str_type = ffi.typeof("ngx_http_lua_ffi_str_t*")
 local ffi_str_size = ffi.sizeof("ngx_http_lua_ffi_str_t")
@@ -58,8 +92,6 @@ ffi.cdef[[
 
     int ngx_http_lua_ffi_req_get_uri_args(ngx_http_request_t *r,
         unsigned char *buf, ngx_http_lua_ffi_table_elt_t *out, int count);
-
-    double ngx_http_lua_ffi_req_start_time(ngx_http_request_t *r);
 
     int ngx_http_lua_ffi_req_get_method(ngx_http_request_t *r);
 
@@ -219,16 +251,6 @@ function ngx.req.get_uri_args(max_args)
     end
 
     return args
-end
-
-
-function ngx.req.start_time()
-    local r = get_request()
-    if not r then
-        error("no request found")
-    end
-
-    return tonumber(C.ngx_http_lua_ffi_req_start_time(r))
 end
 
 

--- a/lib/resty/core/utils.lua
+++ b/lib/resty/core/utils.lua
@@ -3,7 +3,6 @@
 
 local ffi = require "ffi"
 local base = require "resty.core.base"
-base.allows_subsystem("http")
 
 
 local C = ffi.C
@@ -12,12 +11,7 @@ local ffi_copy = ffi.copy
 local byte = string.byte
 local str_find = string.find
 local get_string_buf = base.get_string_buf
-
-
-ffi.cdef[[
-    void ngx_http_lua_ffi_str_replace_char(unsigned char *buf, size_t len,
-        const unsigned char find, const unsigned char replace);
-]]
+local subsystem = ngx.config.subsystem
 
 
 local _M = {
@@ -25,19 +19,27 @@ local _M = {
 }
 
 
-function _M.str_replace_char(str, find, replace)
-    if not str_find(str, find, nil, true) then
-        return str
+if subsystem == "http" then
+    ffi.cdef[[
+    void ngx_http_lua_ffi_str_replace_char(unsigned char *buf, size_t len,
+        const unsigned char find, const unsigned char replace);
+    ]]
+
+
+    function _M.str_replace_char(str, find, replace)
+        if not str_find(str, find, nil, true) then
+            return str
+        end
+
+        local len = #str
+        local buf = get_string_buf(len)
+        ffi_copy(buf, str)
+
+        C.ngx_http_lua_ffi_str_replace_char(buf, len, byte(find),
+                                            byte(replace))
+
+        return ffi_str(buf, len)
     end
-
-    local len = #str
-    local buf = get_string_buf(len)
-    ffi_copy(buf, str)
-
-    C.ngx_http_lua_ffi_str_replace_char(buf, len, byte(find),
-                                        byte(replace))
-
-    return ffi_str(buf, len)
 end
 
 

--- a/t/stream/request.t
+++ b/t/stream/request.t
@@ -1,0 +1,39 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib '.';
+use t::TestCore::Stream;
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 6);
+
+no_long_string();
+check_accum_error_log();
+run_tests();
+
+__DATA__
+
+=== TEST 1: ngx.req.start_time()
+--- stream_server_config
+    content_by_lua_block {
+        local t
+        for i = 1, 500 do
+            t = ngx.req.start_time()
+        end
+        ngx.sleep(0.10)
+        local elapsed = ngx.now() - t
+        ngx.say(t > 1399867351)
+        ngx.say(">= 0.099: ", elapsed >= 0.099)
+        ngx.say("< 0.11: ", elapsed < 0.11)
+        -- ngx.say(t, " ", elapsed)
+    }
+--- stream_response
+true
+>= 0.099: true
+< 0.11: true
+
+--- error_log eval
+qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):3 loop\]/
+--- no_error_log
+[error]
+bad argument type
+stitch


### PR DESCRIPTION
The `ngx.req.start_time()` API is part of `request.lua` which is was
understandably not loaded for the stream subsystem. There existed no
tests for this API in the stream subsystem, so the removal of its
underlying CFunction resulted in `ngx.req.start_time` being `nil` with
no test cases to realize that.

> I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
