### PR TITLE
tests: ocsp.t: specify the maxlen of the buf_size explicitly to avoid test failure.

### DIFF
--- a/t/ocsp.t
+++ b/t/ocsp.t
@@ -42,7 +42,8 @@ __DATA__
                 return
             end
 
-            local url, err = ocsp.get_ocsp_responder_from_der_chain(cert_data)
+            -- specify the max length explicitly here, since string buf size may be too short
+            local url, err = ocsp.get_ocsp_responder_from_der_chain(cert_data, 128)
             if not url then
                 ngx.log(ngx.ERR, "failed to get OCSP responder: ", err)
                 return
@@ -502,7 +503,8 @@ still get an error: truncated
                 return
             end
 
-            local req, err = ocsp.create_ocsp_request(cert_data)
+            -- specify the max length explicitly here, since string buf size may be too short
+            local req, err = ocsp.create_ocsp_request(cert_data, 128)
             if not req then
                 ngx.log(ngx.ERR, "failed to create OCSP request: ", err)
                 return
@@ -959,7 +961,8 @@ OCSP response validation ok
             local resp = f:read("*a")
             f:close()
 
-            local req, err = ocsp.validate_ocsp_response(resp, cert_data)
+            -- specify the max length explicitly here, since string buf size may be too short
+            local req, err = ocsp.validate_ocsp_response(resp, cert_data, 128)
             if not req then
                 ngx.log(ngx.ERR, "failed to validate OCSP response: ", err)
                 return
@@ -1239,7 +1242,8 @@ OCSP response validation ok
             local resp = f:read("*a")
             f:close()
 
-            local req, err = ocsp.validate_ocsp_response(resp, cert_data)
+            -- specify the max length explicitly here, since string buf size may be too short
+            local req, err = ocsp.validate_ocsp_response(resp, cert_data, 128)
             if not req then
                 ngx.log(ngx.ERR, "failed to validate OCSP response: ", err)
                 return
@@ -1331,7 +1335,8 @@ OCSP response validation ok
             local resp = f:read("*a")
             f:close()
 
-            local req, err = ocsp.validate_ocsp_response(resp, cert_data)
+            -- specify the max length explicitly here, since string buf size may be too short
+            local req, err = ocsp.validate_ocsp_response(resp, cert_data, 128)
             if not req then
                 ngx.log(ngx.ERR, "failed to validate OCSP response: ", err)
                 return ngx.exit(ngx.ERROR)


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.