### PR TITLE
tests: pipe.t: increase timeout to 1 second to make it more resilient in mockeagain(W) & valgrind mode.

### DIFF
--- a/t/pipe-stderr.t
+++ b/t/pipe-stderr.t
@@ -783,7 +783,7 @@ end
             local f = io.open("$TEST_NGINX_HTML_DIR/a.lua")
             local code = f:read("*a")
             local proc = helper.run_lua_with_graceful_shutdown("$TEST_NGINX_HTML_DIR", code)
-            proc:set_timeouts(100, 100, 100, 100)
+            proc:set_timeouts(1000, 1000, 1000, 1000)
 
             local data, err = proc:stdout_read_all()
             if not data then

--- a/t/pipe-stderr.t
+++ b/t/pipe-stderr.t
@@ -783,7 +783,7 @@ end
             local f = io.open("$TEST_NGINX_HTML_DIR/a.lua")
             local code = f:read("*a")
             local proc = helper.run_lua_with_graceful_shutdown("$TEST_NGINX_HTML_DIR", code)
-            proc:set_timeouts(1000, 1000, 1000, 1000)
+            proc:set_timeouts(300, 300, 300, 300)
 
             local data, err = proc:stdout_read_all()
             if not data then

--- a/t/pipe.t
+++ b/t/pipe.t
@@ -1589,7 +1589,7 @@ end
             local f = io.open("$TEST_NGINX_HTML_DIR/a.lua")
             local code = f:read("*a")
             local proc = helper.run_lua_with_graceful_shutdown("$TEST_NGINX_HTML_DIR", code)
-            proc:set_timeouts(100, 100, 100, 100)
+            proc:set_timeouts(1000, 1000, 1000, 1000)
 
             local data, err = proc:stdout_read_all()
             if not data then

--- a/t/pipe.t
+++ b/t/pipe.t
@@ -1589,7 +1589,7 @@ end
             local f = io.open("$TEST_NGINX_HTML_DIR/a.lua")
             local code = f:read("*a")
             local proc = helper.run_lua_with_graceful_shutdown("$TEST_NGINX_HTML_DIR", code)
-            proc:set_timeouts(1000, 1000, 1000, 1000)
+            proc:set_timeouts(300, 300, 300, 300)
 
             local data, err = proc:stdout_read_all()
             if not data then


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.