### PR TITLE
tests: run collectgarbage() before ngx_pipe.spawn() to fix mem leaks in check_leak mode.

### DIFF
--- a/t/pipe.t
+++ b/t/pipe.t
@@ -1127,6 +1127,7 @@ hello
 --- config
     location = /t {
         content_by_lua_block {
+            collectgarbage()
             local ngx_pipe = require "ngx.pipe"
             local proc = ngx_pipe.spawn("echo 'hello' && >&2 echo 'world'")
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

In check_leak mode (`TEST_NGINX_CHECK_LEAK_COUNT=1000`), I run the test case (`t/pipe.t`)
100 times in a loop. 

## before

before the changes were made, `k > 0.0` occurred 60 times, and the max
value of `k` is `2.7`:

``` log
LeakTest: [5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5748 5776 5900 5900 5900 5900 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928 5928]
LeakTest: k=2.7
```

## after

If `collectgarbage()` is running at the beginning of each test, `k > 0.0` 
occurred 7 times, and the max value of `k` is `0.1`:

``` log
LeakTest: [4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4688 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692 4692]
LeakTest: k=0.1
```

Maybe it's safe to assume the memory leak has not occurred here.