### PR TITLE
tests: t/pipe.t: --- shutdown_error_log should be excluded from repeat_each() when counting plans.

### DIFF
--- a/t/pipe.t
+++ b/t/pipe.t
@@ -4,7 +4,7 @@ use t::TestCore;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 3 + 20);
+plan tests => repeat_each() * (blocks() * 3 + 19) + 2;
 
 add_block_preprocessor(sub {
     my $block = shift;


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.