### PR TITLE
bugfix: invalid write of size 8 caught by valgrind.

### DIFF
--- a/lib/resty/core/utils.lua
+++ b/lib/resty/core/utils.lua
@@ -33,7 +33,7 @@ if subsystem == "http" then
 
         local len = #str
         local buf = get_string_buf(len)
-        ffi_copy(buf, str)
+        ffi_copy(buf, str, len)
 
         C.ngx_http_lua_ffi_str_replace_char(buf, len, byte(find),
                                             byte(replace))


### PR DESCRIPTION
from https://luajit.org/ext_ffi_api.html

ffi.copy(dst, str)
In this syntax, the source of the copy must be a Lua string. All bytes of the string plus a zero-terminator are copied to dst (i.e. #src+1 bytes).

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
