### PR TITLE
 change: allowing both ngx_lua 0.10.18 and 0.10.19.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -109,7 +109,7 @@ of this library in the particular OpenResty release you are using. Otherwise you
 into serious compatibility issues.
 
 * LuaJIT 2.1 (for now, it is the v2.1 git branch in the official luajit-2.0 git repository: http://luajit.org/download.html )
-* [ngx_http_lua_module](https://github.com/openresty/lua-nginx-module) v0.10.18.
+* [ngx_http_lua_module](https://github.com/openresty/lua-nginx-module) v0.10.19.
 * [ngx_stream_lua_module](https://github.com/openresty/stream-lua-nginx-module) v0.0.9.
 * [lua-resty-lrucache](https://github.com/openresty/lua-resty-lrucache)
 

--- a/lib/resty/core/base.lua
+++ b/lib/resty/core/base.lua
@@ -19,9 +19,9 @@ if subsystem == 'http' then
     local ngx_lua_v = ngx.config.ngx_lua_version
     if not ngx.config
        or not ngx.config.ngx_lua_version
-       or (ngx_lua_v ~= 10018)
+       or (ngx_lua_v ~= 10018 and ngx_lua_v ~= 10019)
     then
-        error("ngx_http_lua_module 0.10.18 required")
+        error("ngx_http_lua_module 0.10.18 or 0.10.19 required")
     end
 
 elseif subsystem == 'stream' then


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.