### PR TITLE
bumped API version to 0.1.21.

### DIFF
--- a/lib/resty/core/base.lua
+++ b/lib/resty/core/base.lua
@@ -133,7 +133,7 @@ local c_buf_type = ffi.typeof("char[?]")
 local _M = new_tab(0, 18)
 
 
-_M.version = "0.1.20"
+_M.version = "0.1.21"
 _M.new_tab = new_tab
 _M.clear_tab = clear_tab
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.