### PR TITLE
doc: fix typo in the example configuration

### DIFF
--- a/lib/ngx/errlog.md
+++ b/lib/ngx/errlog.md
@@ -37,7 +37,7 @@ Capturing nginx error logs with specified log filtering level
 -------------------------------------------------------------
 
 ```nginx
-error logs/error.log info;
+error_log logs/error.log info;
 
 http {
     # enable capturing error logs


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
