### PR TITLE
feature: expose the get_ctx_table API to get the ctx table & support using ctx table from caller when the ctx table is not existing.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,7 @@ Table of Contents
     * [resty.core.shdict](#restycoreshdict)
     * [resty.core.var](#restycorevar)
     * [resty.core.ctx](#restycorectx)
+    * [get_ctx_table](#get_ctx_table)
     * [resty.core.request](#restycorerequest)
     * [resty.core.response](#restycoreresponse)
     * [resty.core.misc](#restycoremisc)
@@ -186,6 +187,16 @@ API Implemented
 ## resty.core.ctx
 
 * [ngx.ctx](https://github.com/openresty/lua-nginx-module#ngxctx)
+
+[Back to TOC](#table-of-contents)
+
+## get_ctx_table
+
+**syntax:** *ctx = get_ctx_table(ctx?)*
+
+Similar to [ngx.ctx](#restycorectx) but it accept an optional `ctx` argument.
+It will use the `ctx` from caller instead of creating a new table
+when the ctx table is not existing.
 
 [Back to TOC](#table-of-contents)
 

--- a/README.markdown
+++ b/README.markdown
@@ -192,11 +192,16 @@ API Implemented
 
 ## get_ctx_table
 
-**syntax:** *ctx = get_ctx_table(ctx?)*
+**syntax:** *ctx = resty.core.ctx.get_ctx_table(ctx?)*
 
-Similar to [ngx.ctx](#restycorectx) but it accept an optional `ctx` argument.
+Similar to [ngx.ctx](#restycorectx) but it accepts an optional `ctx` argument.
 It will use the `ctx` from caller instead of creating a new table
-when the ctx table is not existing.
+when the `ctx` table does not exist.
+
+Notice: the `ctx` table will be used in the current request's whole life cycle.
+Please be very careful when you try to reuse the `ctx` table.
+You need to make sure there is no Lua code using or going to use the `ctx` table
+in the current request before you reusing the `ctx` table in some other place.
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/resty/core/ctx.lua
+++ b/lib/resty/core/ctx.lua
@@ -58,7 +58,7 @@ do
     local in_ssl_phase = ffi.new("int[1]")
     local ssl_ctx_ref = ffi.new("int[1]")
 
-    function get_ctx_table()
+    function get_ctx_table(ctx)
         local r = get_request()
 
         if not r then
@@ -72,25 +72,29 @@ do
 
         local ctxs = registry.ngx_lua_ctx_tables
         if ctx_ref < 0 then
-            local ctx
-
             ctx_ref = ssl_ctx_ref[0]
             if ctx_ref > 0 and ctxs[ctx_ref] then
                 if in_ssl_phase[0] ~= 0 then
                     return ctxs[ctx_ref]
                 end
 
-                ctx = new_tab(0, 4)
+                if not ctx then
+                    ctx = new_tab(0, 4)
+                end
+
                 ctx = setmetatable(ctx, ctxs[ctx_ref])
 
             else
                 if in_ssl_phase[0] ~= 0 then
-                    ctx = new_tab(1, 4)
+                    if not ctx then
+                        ctx = new_tab(1, 4)
+                    end
+
                     -- to avoid creating another table, we assume the users
                     -- won't overwrite the `__index` key
                     ctx.__index = ctx
 
-                else
+                elseif not ctx then
                     ctx = new_tab(0, 4)
                 end
             end
@@ -105,6 +109,7 @@ do
     end
 end
 register_getter("ctx", get_ctx_table)
+_M.get_ctx_table = get_ctx_table
 
 
 local function set_ctx_table(ctx)

--- a/t/ctx.t
+++ b/t/ctx.t
@@ -901,3 +901,31 @@ GET /t
 ctx should be a table while getting a nil
 --- no_error_log
 [error]
+
+
+
+=== TEST 13: get_ctx_table
+--- config
+    location = /t {
+        content_by_lua_block {
+            local get_ctx_table = require "resty.core.ctx" .get_ctx_table
+
+            local reused_ctx = {}
+            local ctx = get_ctx_table(reused_ctx)
+            if ctx == reused_ctx then
+                ngx.say("reused")
+            end
+
+            local ctx2 = get_ctx_table()
+            if ctx2 == reused_ctx then
+                ngx.say("reused again")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+reused
+reused again
+--- no_error_log
+[error]


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.