### PR TITLE
tests: t/ssl.t fix test failure

### DIFF
--- a/t/ssl.t
+++ b/t/ssl.t
@@ -2261,6 +2261,8 @@ qr/subject=\/?C(?<eq>\s?=\s?)US(?<sep>\/|,\s)ST\k<eq>California\k<sep>L\k<eq>San
 [error]
 [alert]
 
+--- timeout: 4
+
 
 
 === TEST 22: tls version - TLSv1.3

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -2264,7 +2264,6 @@ qr/subject=\/?C(?<eq>\s?=\s?)US(?<sep>\/|,\s)ST\k<eq>California\k<sep>L\k<eq>San
 --- timeout: 4
 
 
-
 === TEST 22: tls version - TLSv1.3
 --- skip_openssl: 6: < 1.1.1
 --- http_config


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

When I run this test case locally, it failed to get the reponse with the following outputs.  

```
^_^$ sh go.sh t/ssl.t
t/ssl.t .. 13/326
#   Failed test 'ERROR: client socket timed out - TEST 21: yield during doing handshake with client which uses low version OpenSSL
# '
#   at /usr/local/share/perl/5.26.1/Test/Nginx/Socket.pm line 2062.

#   Failed test 'TEST 21: yield during doing handshake with client which uses low version OpenSSL - status code ok'
#   at /usr/local/share/perl/5.26.1/Test/Nginx/Socket.pm line 948.
#          got: ''
#     expected: '200'

#   Failed test 'TEST 21: yield during doing handshake with client which uses low version OpenSSL - response_body - response is expected (repeated req 0, req 0)'
#   at /usr/local/share/perl/5.26.1/Test/Nginx/Socket.pm line 1589.
#          got: ''
#     expected: 'ok
# '
t/ssl.t .. 20/326
#   Failed test 'ERROR: client socket timed out - TEST 21: yield during doing handshake with client which uses low version OpenSSL
# '
#   at /usr/local/share/perl/5.26.1/Test/Nginx/Socket.pm line 2062.

#   Failed test 'TEST 21: yield during doing handshake with client which uses low version OpenSSL - status code ok'
#   at /usr/local/share/perl/5.26.1/Test/Nginx/Socket.pm line 948.
#          got: ''
#     expected: '200'

#   Failed test 'TEST 21: yield during doing handshake with client which uses low version OpenSSL - response_body - response is expected (repeated req 1, req 0)'
#   at /usr/local/share/perl/5.26.1/Test/Nginx/Socket.pm line 1589.
#          got: ''
#     expected: 'ok
# '
t/ssl.t .. Failed 6/326 subtests

Test Summary Report
-------------------
t/ssl.t (Wstat: 0 Tests: 328 Failed: 8)
  Failed tests:  13-15, 20-22, 327-328
  Parse errors: Bad plan.  You planned 326 tests but ran 328.
Files=1, Tests=328, 12 wallclock secs ( 0.09 usr  0.01 sys +  1.05 cusr  0.37 csys =  1.52 CPU)
Result: FAIL
```

It seems the test client timed out beforing receiving response, because `ngx.log(ngx.INFO, out)` has printed log successly. Noticing the max timeout of test server is about 3s, the timeout of client should be longer than it to ensure the test case to pass

```
    location /t {
        content_by_lua_block {
            ngx.shared.done:delete("handshake")
            local addr = ngx.var.addr;
            local req = "'GET / HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n'"
            local f, err = io.popen("echo -n " .. req .. " | timeout 3s openssl s_client -connect 127.0.0.1:$TEST_NGINX_RAND_PORT_1")
            if not f then
                ngx.say(err)
                return
            end

            local step = 0.001
            while step < 2 do
                ngx.sleep(step)
                step = step * 2

                if ngx.shared.done:get("handshake") then
                    local out = f:read('*a')
                    ngx.log(ngx.INFO, out)
                    ngx.say("ok")
                    f:close()
                    return
                end
            end

            ngx.log(ngx.ERR, "openssl client handshake timeout")
        }
    }
```