### PR TITLE
optimization: a new upvalue table for the ctxs holder to make LuaJIT JIT compiler happy to generate more efficient machine code.

### DIFF
--- a/lib/resty/core/ctx.lua
+++ b/lib/resty/core/ctx.lua
@@ -53,6 +53,12 @@ local _M = {
 }
 
 
+-- use a new ctxs table to make LuaJIT JIT compiler happy to generate more
+-- efficient machine code.
+local ctxs = {}
+registry.ngx_lua_ctx_tables = ctxs
+
+
 local get_ctx_table
 do
     local in_ssl_phase = ffi.new("int[1]")
@@ -70,7 +76,6 @@ do
             error("no request ctx found")
         end
 
-        local ctxs = registry.ngx_lua_ctx_tables
         if ctx_ref < 0 then
             ctx_ref = ssl_ctx_ref[0]
             if ctx_ref > 0 and ctxs[ctx_ref] then
@@ -129,7 +134,6 @@ local function set_ctx_table(ctx)
         error("no request ctx found")
     end
 
-    local ctxs = registry.ngx_lua_ctx_tables
     if ctx_ref < 0 then
         ctx_ref = ref_in_table(ctxs, ctx)
         ngx_lua_ffi_set_ctx_ref(r, ctx_ref)


### PR DESCRIPTION
Now `ngx.ctx` is 80% faster than the old implementation.

Here is the Lua bench script:
```
local function table_fetch()
    local ctx = ngx.ctx
    local t = ctx.t
    if not t then
        t = 1
        ctx.t = t
    end

    return t
end


local ctx = {}
for i = 1, 1000 * 1000 * 1000 do
    table_fetch()
end

print("done")
```

Here is the bench result:
```
# old implementation:
$ time resty ctx.lua
done

real    0m8.575s
user    0m8.461s
sys     0m0.055s

# new implementation
$ time resty ctx.lua

real    0m4.672s
user    0m4.578s
sys     0m0.069s
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
