### PR TITLE
bugfix: ngx.re.sub/gsub incorrectly dropped the last character.

### DIFF
--- a/lib/resty/core/regex.lua
+++ b/lib/resty/core/regex.lua
@@ -1038,7 +1038,7 @@ local function re_sub_func_helper(subj, regex, replace, opts, global)
     end
 
     if count > 0 then
-        if pos < subj_len then
+        if cp_pos < subj_len then
             local suffix_len = subj_len - cp_pos
 
             local new_dst_len = dst_len + suffix_len
@@ -1167,7 +1167,7 @@ local function re_sub_str_helper(subj, regex, replace, opts, global)
     end
 
     if count > 0 then
-        if pos < subj_len then
+        if cp_pos < subj_len then
             local suffix_len = subj_len - cp_pos
 
             local new_dst_len = dst_len + suffix_len


### PR DESCRIPTION
In order to avoid an infinite loop when the regex matches an empty
sub string, we set the match offset(`pos`) one character ahead of
cap\[1\](`cp_pos`) and begin a new match process(in ngx.re.gsub). Then
we break out the loop and make a comparison with #subj to check
whether there is a trailer to concat, in which we should not use
the match offset but the last cap[1].

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
