### PR TITLE
tests: t/balancer.t: use RegExp instead of strict character match.

### DIFF
--- a/t/balancer.t
+++ b/t/balancer.t
@@ -830,8 +830,8 @@ hello from balancer by lua!
 GET /t
 --- response_body_like: 502 Bad Gateway
 --- error_code: 502
---- error_log
-[lua] log_by_lua(nginx.conf:59):2: ngx.var.upstream_addr is 127.0.0.3:12345, 127.0.0.3:12346
+--- error_log eval
+qr/log_by_lua\(nginx.conf:\d+\):\d+: ngx.var.upstream_addr is 127.0.0.3:12345, 127.0.0.3:12346/
 --- no_error_log
 [alert]
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.