### PR TITLE
optimization: no need call ffi function to set resp header when value was empty string

### DIFF
--- a/lib/resty/core/response.lua
+++ b/lib/resty/core/response.lua
@@ -95,6 +95,10 @@ local function set_resp_header(tb, key, value, no_override)
             end
             sval_len = #sval
 
+            if sval_len == 0 then
+                return
+            end
+
             mvals_len = 0
         end
 


### PR DESCRIPTION


I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
