### PR TITLE
feature: add ngx.worker.pids api to get all workers pid map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/openresty-devel-utils.git
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b feat/get_pids https://github.com/attenuation/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/lua-resty-lrucache.git
@@ -75,6 +75,7 @@ install:
   - git clone https://github.com/openresty/mockeagain.git
   - git clone https://github.com/openresty/test-nginx.git
   - git clone https://github.com/openresty/stream-lua-nginx-module.git ../stream-lua-nginx-module
+  - git clone -b feat/get_pids https://github.com/attenuation/stream-lua-nginx-module.git ../stream-lua-nginx-module
 
 script:
   - cd luajit2/

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,6 @@ install:
   - git clone https://github.com/openresty/set-misc-nginx-module.git ../set-misc-nginx-module
   - git clone https://github.com/openresty/mockeagain.git
   - git clone https://github.com/openresty/test-nginx.git
-  - git clone https://github.com/openresty/stream-lua-nginx-module.git ../stream-lua-nginx-module
   - git clone -b feat/get_pids https://github.com/attenuation/stream-lua-nginx-module.git ../stream-lua-nginx-module
 
 script:

--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -61,9 +61,14 @@ function ngx.worker.pid()
     return ngx_lua_ffi_worker_pid()
 end
 
+local size_ptr = ffi_new("size_t[1]")
+local pids_ptr = ffi_new("int[1024]") -- using NGX_MAX_PROCESSES
+
 function ngx.worker.pids()
-    local size_ptr = ffi_new("size_t[1]")
-    local pids_ptr = ffi_new("int[1024]") -- using NGX_MAX_PROCESSES
+    if ngx.get_phase() == "init" or ngx.get_phase() == "init_worker" then
+        return nil, "API disabled in the current context"
+    end
+
     local res = ngx_lua_ffi_worker_pids(pids_ptr, size_ptr)
 
     local pids = {}

--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -13,6 +13,7 @@ local subsystem = ngx.config.subsystem
 
 local ngx_lua_ffi_worker_id
 local ngx_lua_ffi_worker_pid
+local ngx_lua_ffi_worker_pids
 local ngx_lua_ffi_worker_count
 local ngx_lua_ffi_worker_exiting
 

--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -24,7 +24,7 @@ if subsystem == "http" then
     ffi.cdef[[
     int ngx_http_lua_ffi_worker_id(void);
     int ngx_http_lua_ffi_worker_pid(void);
-    int ngx_http_lua_ffi_worker_pids(int *pids, size_t *pidslen);
+    int ngx_http_lua_ffi_worker_pids(int *pids, size_t *pids_len);
     int ngx_http_lua_ffi_worker_count(void);
     int ngx_http_lua_ffi_worker_exiting(void);
     ]]
@@ -39,7 +39,7 @@ elseif subsystem == "stream" then
     ffi.cdef[[
     int ngx_stream_lua_ffi_worker_id(void);
     int ngx_stream_lua_ffi_worker_pid(void);
-    int ngx_stream_lua_ffi_worker_pids(int *pids, size_t *pidslen);
+    int ngx_stream_lua_ffi_worker_pids(int *pids, size_t *pids_len);
     int ngx_stream_lua_ffi_worker_count(void);
     int ngx_stream_lua_ffi_worker_exiting(void);
     ]]

--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -73,7 +73,7 @@ function ngx.worker.pids()
 
     local pids = {}
     if res == 0 then
-        for i=1, tonumber(size_ptr[0]) do
+        for i = 1, tonumber(size_ptr[0]) do
             pids[i] = pids_ptr[i-1]
         end
     end

--- a/t/worker.t
+++ b/t/worker.t
@@ -8,7 +8,7 @@ use t::TestCore;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6);
+plan tests => repeat_each() * (blocks() * 6 - 3);
 
 #no_diff();
 #no_long_string();
@@ -117,3 +117,34 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
 [error]
  -- NYI:
  stitch
+
+
+
+=== TEST 5: ngx.worker.pids
+--- config
+    location /lua {
+        content_by_lua '
+            local pids = ngx.worker.pids()
+            local pid = ngx.worker.pid()
+            ngx.say("worker pid: ", pid)
+            local count = ngx.worker.count()
+            if count ~= #pids then
+                ngx.say("worker pids is wrong.")
+            end
+            for i = 1, count do
+                if pids[i] == pid then
+                    ngx.say("worker pid is correct.")
+                    return
+                end
+            end
+            ngx.say("worker pid is wrong.")
+        ';
+    }
+--- request
+GET /lua
+--- response_body_like
+worker pid: \d+
+worker pid is correct\.
+--- no_error_log
+[error]
+

--- a/t/worker.t
+++ b/t/worker.t
@@ -123,7 +123,7 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
 === TEST 5: ngx.worker.pids
 --- config
     location /lua {
-        content_by_lua '
+        content_by_lua_block {
             local pids = ngx.worker.pids()
             local pid = ngx.worker.pid()
             ngx.say("worker pid: ", pid)
@@ -138,7 +138,7 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
                 end
             end
             ngx.say("worker pid is wrong.")
-        ';
+        }
     }
 --- request
 GET /lua


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

Add `ngx.woker.pids()` API to get Nginx all worker pids
subset pull request is  
https://github.com/openresty/lua-nginx-module/pull/2086
https://github.com/openresty/stream-lua-nginx-module/pull/299
