### PR TITLE
doc: fix verify_client first added version

### DIFF
--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -516,7 +516,7 @@ Returns `true` on success, or a `nil` value and a string describing the error ot
 Note that TLS is not terminated when verification fails. You need to examine Nginx variable `$ssl_client_verify`
 later to determine next steps.
 
-This function was first added in version `0.1.20`.
+This function was first added in version `0.1.24`.
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
The version described in the documentation is wrong, the verify_client was first introduced at version 0.1.24 https://github.com/openresty/lua-resty-core/commit/fa672ab3584da908991d0f20384a2b9d8188bad9


I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
