### PR TITLE
optimize: avoid NYI in the get_string_buf function.

### DIFF
--- a/lib/resty/core/base.lua
+++ b/lib/resty/core/base.lua
@@ -190,7 +190,8 @@ end
 function _M.get_string_buf(size, must_alloc)
     -- ngx.log(ngx.ERR, "str buf size: ", str_buf_size)
     if size > str_buf_size or must_alloc then
-        return ffi_new(c_buf_type, size)
+        local buf = ffi_new(c_buf_type, size)
+        return buf
     end
 
     if not str_buf then


### PR DESCRIPTION
TRACE --- (1/0) base.lua:192 -- NYI: return to lower frame at ffi.new

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
