### PR TITLE
tests: remove 'wait' since it makes the t/process-type-hup.t more lik…

### DIFF
--- a/t/process-type-hup.t
+++ b/t/process-type-hup.t
@@ -86,4 +86,3 @@ init_worker_by_lua(nginx.conf:48):6: process type: privileged
 --- no_error_log
 [error]
 --- skip_nginx: 4: < 1.11.2
---- wait: 0.1


### PR DESCRIPTION
…ely to fail in valgrind mode.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
