### PR TITLE
tests: explicitly output the result name in the t/time.t and t/stream…

### DIFF
--- a/t/stream/time.t
+++ b/t/stream/time.t
@@ -158,11 +158,11 @@ stitch
         end
         ngx.say(t >= uptime)
         local diff = t - uptime
-        ngx.say(diff < 10)
+        ngx.say("< 10: ", diff < 10)
     }
 --- stream_response
 true
-true
+< 10: true
 
 --- error_log eval
 qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):11 loop\]/
@@ -190,11 +190,11 @@ stitch
         end
         ngx.say(t >= uptime)
         local diff = t - uptime
-        ngx.say(diff < 0.1)
+        ngx.say("< 0.1: ", diff < 0.1)
     }
 --- stream_response
 true
-true
+< 0.1: true
 
 --- error_log eval
 qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):11 loop\]/

--- a/t/time.t
+++ b/t/time.t
@@ -383,14 +383,14 @@ stitch
             end
             ngx.say(t >= uptime)
             local diff = t - uptime
-            ngx.say(diff < 0.01)
+            ngx.say("< 0.01: ", diff < 0.01)
         }
     }
 --- request
 GET /t
 --- response_body
 true
-true
+< 0.01: true
 
 --- error_log eval
 qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):11 loop\]/


### PR DESCRIPTION
…/time.t to make it easier to ignore error results in test modes like valgrind.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
