### PR TITLE
tests: more explicitly output the result name in the t/time.t and t/s…

### DIFF
--- a/t/stream/time.t
+++ b/t/stream/time.t
@@ -49,11 +49,11 @@ stitch
         end
         ngx.say(t > 1400960598)
         local diff = os.time() - t
-        ngx.say(diff <= 1)
+        ngx.say("<= 1: ", diff <= 1)
     }
 --- stream_response
 true
-true
+<= 1: true
 
 --- error_log eval
 qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):3 loop\]/

--- a/t/time.t
+++ b/t/time.t
@@ -61,14 +61,14 @@ stitch
             end
             ngx.say(t > 1400960598)
             local diff = os.time() - t
-            ngx.say(diff <= 1)
+            ngx.say("<= 1: ", diff <= 1)
         }
     }
 --- request
 GET /t
 --- response_body
 true
-true
+<= 1: true
 
 --- error_log eval
 qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):3 loop\]/
@@ -346,14 +346,14 @@ stitch
             end
             ngx.say(t >= uptime)
             local diff = t - uptime
-            ngx.say(diff < 10)
+            ngx.say("< 10: ", diff < 10)
         }
     }
 --- request
 GET /t
 --- response_body
 true
-true
+< 10: true
 
 --- error_log eval
 qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):11 loop\]/


### PR DESCRIPTION
…tream/time.t to make it easier to ignore error results in test modes like valgrind.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
