### PR TITLE
bugfix: request headers contains "_" should be case-insensitive matched.

### DIFF
--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -116,8 +116,8 @@ local req_headers_mt = {
     __index = function (tb, key)
         key = lower(key)
         local value = rawget(tb, key)
-        if value == nil then
-            if value == nil and str_find(key, '_', 1, true) then
+        if value == nil and str_find(key, '_', 1, true) then
+            value = rawget(tb, (str_replace_char(key, '_', '-')))
         end
         return value
     end

--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -114,7 +114,12 @@ local truncated = ffi.new("int[1]")
 
 local req_headers_mt = {
     __index = function (tb, key)
-        return rawget(tb, (str_replace_char(lower(key), '_', '-')))
+        key = lower(key)
+        local value = rawget(tb, key)
+        if value == nil then
+            value =  rawget(tb, (str_replace_char(key, '_', '-')))
+        end
+        return value
     end
 }
 

--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -20,6 +20,7 @@ local get_string_buf = base.get_string_buf
 local get_size_ptr = base.get_size_ptr
 local setmetatable = setmetatable
 local lower = string.lower
+local find = string.find
 local rawget = rawget
 local ngx = ngx
 local get_request = base.get_request
@@ -116,7 +117,7 @@ local req_headers_mt = {
     __index = function (tb, key)
         key = lower(key)
         local value = rawget(tb, key)
-        if value == nil and str_find(key, '_', 1, true) then
+        if value == nil and find(key, '_', 1, true) then
             value = rawget(tb, (str_replace_char(key, '_', '-')))
         end
         return value

--- a/lib/resty/core/request.lua
+++ b/lib/resty/core/request.lua
@@ -117,7 +117,7 @@ local req_headers_mt = {
         key = lower(key)
         local value = rawget(tb, key)
         if value == nil then
-            value =  rawget(tb, (str_replace_char(key, '_', '-')))
+            if value == nil and str_find(key, '_', 1, true) then
         end
         return value
     end

--- a/t/request.t
+++ b/t/request.t
@@ -170,10 +170,10 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
 --- request
 GET /t
 --- response_body
-foo_BAR: foo
 baz: baz
 connection: close
 foo-bar: foo
+foo_BAR: foo
 host: localhost
 x-bar-header: bar
 X_Bar_Header: bar

--- a/t/request.t
+++ b/t/request.t
@@ -170,12 +170,12 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
 --- request
 GET /t
 --- response_body
+foo_BAR: foo
 baz: baz
 connection: close
 foo-bar: foo
-foo_BAR: foo
 host: localhost
-x-bar-header: bar
+x_bar_header: bar
 X_Bar_Header: bar
 x_Bar_Header: bar
 x_bar_header: bar

--- a/t/request.t
+++ b/t/request.t
@@ -140,6 +140,8 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
 
 
 === TEST 4: ngx.req.get_headers (metatable)
+--- http_config
+    underscores_in_headers on;
 --- config
     location = /t {
         set $foo hello;
@@ -159,6 +161,10 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):4 loop\]/
             for _, k in ipairs(keys) do
                 ngx.say(k, ": ", headers[k])
             end
+
+            ngx.say("X_Bar_Header: ", headers["X_Bar_Header"])
+            ngx.say("x_Bar_Header: ", headers["x_Bar_Header"])
+            ngx.say("x_bar_header: ", headers["x_bar_header"])
         }
     }
 --- request
@@ -169,9 +175,13 @@ baz: baz
 connection: close
 foo-bar: foo
 host: localhost
+X_Bar_Header: bar
+x_Bar_Header: bar
+x_bar_header: bar
 --- more_headers
 Foo-Bar: foo
 Baz: baz
+X_Bar_Header: bar
 --- wait: 0.2
 --- error_log eval
 qr/\[TRACE\s+\d+ .*? -> \d+\]/

--- a/t/request.t
+++ b/t/request.t
@@ -175,6 +175,7 @@ baz: baz
 connection: close
 foo-bar: foo
 host: localhost
+x-bar-header: bar
 X_Bar_Header: bar
 x_Bar_Header: bar
 x_bar_header: bar


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.


Fix a bug that request header contains "_" unable to be case-insensitive matched.
e.g. 
```lua
-- Request with headers:
-- X_Foo_Header: foo

local value = ngx.req.get_headers()["X_Foo_Header"]  -- nil
```