### PR TITLE
bugfix: windows also need to support ngx_lua_ffi_worker_pids.

### DIFF
--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -87,7 +87,8 @@ if jit.os ~= "Windows" then
 
         local pids = {}
         local size_ptr = get_size_ptr()
-        local worker_cnt = ngx.worker.count()
+        -- the old and the new workers coexist during reloading
+        local worker_cnt = ngx.worker.count() * 4
         if worker_cnt == 0 then
             return pids
         end


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
