### PR TITLE
feature: expose NGX_ABORT using FFI_ABORT

### DIFF
--- a/lib/resty/core/base.lua
+++ b/lib/resty/core/base.lua
@@ -241,6 +241,7 @@ _M.FFI_AGAIN = -2
 _M.FFI_BUSY = -3
 _M.FFI_DONE = -4
 _M.FFI_DECLINED = -5
+_M.FFI_ABORT = -6
 
 
 do

--- a/t/count.t
+++ b/t/count.t
@@ -40,6 +40,6 @@ probe process("$LIBLUA_PATH").function("rehashtab") {
 }
 
 --- response_body
-base size: 19
+base size: 20
 --- no_error_log
 [error]


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

Expose `NGX_ABORT` through `FFI_ABORT` - see https://github.com/nginx/nginx/blob/master/src/core/ngx_core.h#L44