### PR TITLE
optimize: small optimization of `ngx.worker.pids()`

### DIFF
--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -73,12 +73,7 @@ end
 
 
 if is_not_windows then
-    local ngx_phase
-
     if subsystem == "http" then
-        require "resty.core.phase"  -- for ngx.get_phase
-        ngx_phase = ngx.get_phase
-
         ffi.cdef[[
         int ngx_http_lua_ffi_worker_pids(int *pids, size_t *pids_len);
         ]]
@@ -95,11 +90,9 @@ if is_not_windows then
 
 
     function ngx.worker.pids()
-        if ngx_phase then
-            local phase = ngx_phase()
-            if phase == "init" or phase == "init_worker" then
-                return nil, "API disabled in the current context"
-            end
+        local phase = ngx.get_phase()
+        if phase == "init" or phase == "init_worker" then
+            return nil, "API disabled in the current context"
         end
 
         local pids = {}

--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -73,7 +73,12 @@ end
 
 
 if is_not_windows then
+    local ngx_phase
+
     if subsystem == "http" then
+        require "resty.core.phase"  -- for ngx.get_phase
+        ngx_phase = ngx.get_phase
+
         ffi.cdef[[
         int ngx_http_lua_ffi_worker_pids(int *pids, size_t *pids_len);
         ]]
@@ -89,14 +94,12 @@ if is_not_windows then
     end
 
 
-    require "resty.core.phase"  -- for ngx.get_phase
-    local ngx_phase = ngx.get_phase
-
-
     function ngx.worker.pids()
-        local phase = ngx_phase()
-        if phase == "init" or phase == "init_worker" then
-            return nil, "API disabled in the current context"
+        if ngx_phase then
+            local phase = ngx_phase()
+            if phase == "init" or phase == "init_worker" then
+                return nil, "API disabled in the current context"
+            end
         end
 
         local pids = {}

--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -89,15 +89,20 @@ if is_not_windows then
     end
 
 
+    require "resty.core.phase"  -- for ngx.get_phase
+    local ngx_phase = ngx.get_phase
+
+
     function ngx.worker.pids()
-        if ngx.get_phase() == "init" or ngx.get_phase() == "init_worker" then
+        local phase = ngx_phase()
+        if phase == "init" or phase == "init_worker" then
             return nil, "API disabled in the current context"
         end
 
         local pids = {}
         local size_ptr = get_size_ptr()
         -- the old and the new workers coexist during reloading
-        local worker_cnt = ngx.worker.count() * 4
+        local worker_cnt = ngx_lua_ffi_worker_count() * 4
         if worker_cnt == 0 then
             return pids
         end
@@ -116,6 +121,7 @@ if is_not_windows then
         return pids
     end
 end
+
 
 function ngx.worker.id()
     local id = ngx_lua_ffi_worker_id()

--- a/lib/resty/core/worker.lua
+++ b/lib/resty/core/worker.lua
@@ -74,6 +74,8 @@ end
 
 if is_not_windows then
     if subsystem == "http" then
+        require "resty.core.phase"  -- for ngx.get_phase
+
         ffi.cdef[[
         int ngx_http_lua_ffi_worker_pids(int *pids, size_t *pids_len);
         ]]
@@ -88,9 +90,10 @@ if is_not_windows then
         ngx_lua_ffi_worker_pids = C.ngx_stream_lua_ffi_worker_pids
     end
 
+    local ngx_phase = ngx.get_phase
 
     function ngx.worker.pids()
-        local phase = ngx.get_phase()
+        local phase = ngx_phase()
         if phase == "init" or phase == "init_worker" then
             return nil, "API disabled in the current context"
         end


### PR DESCRIPTION
- call `ngx_lua_ffi_worker_count()` directly
- cache the result of `ngx.get_phase()`
