### PR TITLE
tests: t/pipe.t: increase the timeout to 10s for TEST 27.

### DIFF
--- a/t/pipe.t
+++ b/t/pipe.t
@@ -1025,6 +1025,7 @@ MD5\([^)]+\)= 8bc944dbd052ef51652e70a5104492e3
     }
 --- response_body
 closed
+--- timeout: 10s
 
 
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
