### PR TITLE
feature: Add parse_der_cert and parse_der_priv_key functions

### DIFF
--- a/lib/ngx/ssl.lua
+++ b/lib/ngx/ssl.lua
@@ -33,6 +33,7 @@ local ngx_lua_ffi_ssl_get_tls1_version
 local ngx_lua_ffi_parse_pem_cert
 local ngx_lua_ffi_parse_pem_priv_key
 local ngx_lua_ffi_parse_der_cert
+local ngx_lua_ffi_parse_der_priv_key
 local ngx_lua_ffi_set_cert
 local ngx_lua_ffi_set_priv_key
 local ngx_lua_ffi_free_cert

--- a/lib/ngx/ssl.lua
+++ b/lib/ngx/ssl.lua
@@ -32,6 +32,7 @@ local ngx_lua_ffi_priv_key_pem_to_der
 local ngx_lua_ffi_ssl_get_tls1_version
 local ngx_lua_ffi_parse_pem_cert
 local ngx_lua_ffi_parse_pem_priv_key
+local ngx_lua_ffi_parse_der_cert
 local ngx_lua_ffi_set_cert
 local ngx_lua_ffi_set_priv_key
 local ngx_lua_ffi_free_cert
@@ -77,6 +78,12 @@ if subsystem == 'http' then
     void *ngx_http_lua_ffi_parse_pem_priv_key(const unsigned char *pem,
         size_t pem_len, char **err);
 
+    void *ngx_http_lua_ffi_parse_der_cert(const char *data,
+        size_t len, char **err);
+
+    void *ngx_http_lua_ffi_parse_der_priv_key(const char *data, size_t len,
+        char **err) ;
+
     int ngx_http_lua_ffi_set_cert(void *r, void *cdata, char **err);
 
     int ngx_http_lua_ffi_set_priv_key(void *r, void *cdata, char **err);
@@ -103,6 +110,8 @@ if subsystem == 'http' then
     ngx_lua_ffi_ssl_get_tls1_version = C.ngx_http_lua_ffi_ssl_get_tls1_version
     ngx_lua_ffi_parse_pem_cert = C.ngx_http_lua_ffi_parse_pem_cert
     ngx_lua_ffi_parse_pem_priv_key = C.ngx_http_lua_ffi_parse_pem_priv_key
+    ngx_lua_ffi_parse_der_cert = C.ngx_http_lua_ffi_parse_der_cert
+    ngx_lua_ffi_parse_der_priv_key = C.ngx_http_lua_ffi_parse_der_priv_key
     ngx_lua_ffi_set_cert = C.ngx_http_lua_ffi_set_cert
     ngx_lua_ffi_set_priv_key = C.ngx_http_lua_ffi_set_priv_key
     ngx_lua_ffi_free_cert = C.ngx_http_lua_ffi_free_cert
@@ -379,6 +388,26 @@ end
 
 function _M.parse_pem_priv_key(pem)
     local pkey = ngx_lua_ffi_parse_pem_priv_key(pem, #pem, errmsg)
+    if pkey ~= nil then
+        return ffi_gc(pkey, ngx_lua_ffi_free_priv_key)
+    end
+
+    return nil, ffi_str(errmsg[0])
+end
+
+
+function _M.parse_der_cert(der)
+    local cert = ngx_lua_ffi_parse_der_cert(der, #der, errmsg)
+    if cert ~= nil then
+        return ffi_gc(cert, ngx_lua_ffi_free_cert)
+    end
+
+    return nil, ffi_str(errmsg[0])
+end
+
+
+function _M.parse_der_priv_key(der)
+    local pkey = ngx_lua_ffi_parse_der_priv_key(der, #der, errmsg)
     if pkey ~= nil then
         return ffi_gc(pkey, ngx_lua_ffi_free_priv_key)
     end

--- a/lib/ngx/ssl.lua
+++ b/lib/ngx/ssl.lua
@@ -155,8 +155,14 @@ elseif subsystem == 'stream' then
     void *ngx_stream_lua_ffi_parse_pem_cert(const unsigned char *pem,
         size_t pem_len, char **err);
 
+    void *ngx_stream_lua_ffi_parse_der_cert(const unsigned char *der,
+        size_t der_len, char **err);
+
     void *ngx_stream_lua_ffi_parse_pem_priv_key(const unsigned char *pem,
         size_t pem_len, char **err);
+
+    void *ngx_stream_lua_ffi_parse_der_priv_key(const unsigned char *der,
+        size_t der_len, char **err);
 
     int ngx_stream_lua_ffi_set_cert(void *r, void *cdata, char **err);
 
@@ -183,7 +189,9 @@ elseif subsystem == 'stream' then
     ngx_lua_ffi_priv_key_pem_to_der = C.ngx_stream_lua_ffi_priv_key_pem_to_der
     ngx_lua_ffi_ssl_get_tls1_version = C.ngx_stream_lua_ffi_ssl_get_tls1_version
     ngx_lua_ffi_parse_pem_cert = C.ngx_stream_lua_ffi_parse_pem_cert
+    ngx_lua_ffi_parse_der_cert = C.ngx_stream_lua_ffi_parse_der_cert
     ngx_lua_ffi_parse_pem_priv_key = C.ngx_stream_lua_ffi_parse_pem_priv_key
+    ngx_lua_ffi_parse_der_priv_key = C.ngx_stream_lua_ffi_parse_der_priv_key
     ngx_lua_ffi_set_cert = C.ngx_stream_lua_ffi_set_cert
     ngx_lua_ffi_set_priv_key = C.ngx_stream_lua_ffi_set_priv_key
     ngx_lua_ffi_free_cert = C.ngx_stream_lua_ffi_free_cert

--- a/lib/ngx/ssl.md
+++ b/lib/ngx/ssl.md
@@ -24,6 +24,8 @@ Table of Contents
     * [get_tls1_version_str](#get_tls1_version_str)
     * [parse_pem_cert](#parse_pem_cert)
     * [parse_pem_priv_key](#parse_pem_priv_key)
+    * [parse_der_cert](#parse_der_cert)
+    * [parse_der_priv_key](#parse_der_priv_key)
     * [set_cert](#set_cert)
     * [set_priv_key](#set_priv_key)
     * [verify_client](#verify_client)
@@ -457,6 +459,41 @@ This function was first added in version `0.1.7`.
 
 [Back to TOC](#table-of-contents)
 
+parse_der_cert
+--------------
+**syntax:** *cert_chain, err = ssl.parse_der_cert(der_cert_chain)*
+
+**context:** *any*
+
+Converts the DER-formated SSL certificate chain data into an opaque cdata pointer (for later uses
+in the [set_cert](#set_cert)
+function, for example).
+
+In case of failures, returns `nil` and a string describing the error.
+
+You can always use libraries like [lua-resty-lrucache](https://github.com/openresty/lua-resty-lrucache#readme)
+to cache the cdata result.
+
+This function can be called in any context.
+
+[Back to TOC](#table-of-contents)
+
+parse_der_priv_key
+------------------
+**syntax:** *priv_key, err = ssl.parse_der_priv_key(der_priv_key)*
+
+**context:** *any*
+
+Converts the DER-formatted SSL private key data into an opaque cdata pointer (for later uses
+in the [set_priv_key](#set_priv_key)
+function, for example).
+
+In case of failures, returns `nil` and a string describing the error.
+
+This function can be called in any context.
+
+[Back to TOC](#table-of-contents)
+
 set_cert
 --------
 **syntax:** *ok, err = ssl.set_cert(cert_chain)*
@@ -464,7 +501,7 @@ set_cert
 **context:** *ssl_certificate_by_lua&#42;*
 
 Sets the SSL certificate chain opaque pointer returned by the
-[parse_pem_cert](#parse_pem_cert) function for the current SSL connection.
+[parse_pem_cert](#parse_pem_cert) or [parse_der_cert](#parse_der_cert)function for the current SSL connection.
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
 
@@ -483,7 +520,7 @@ set_priv_key
 **context:** *ssl_certificate_by_lua&#42;*
 
 Sets the SSL private key opaque pointer returned by the
-[parse_pem_priv_key](#parse_pem_priv_key) function for the current SSL connection.
+[parse_pem_priv_key](#parse_pem_priv_key) or [parse_der_priv_key](#parse_der_priv_key) function for the current SSL connection.
 
 Returns `true` on success, or a `nil` value and a string describing the error otherwise.
 

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -2837,3 +2837,134 @@ lua ssl server name: "test.com"
 [error]
 [alert]
 [emerg]
+
+=== TEST 29: parse PEM cert and key to cdata
+--- http_config
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   test.com;
+        ssl_certificate_by_lua_block {
+            local ssl = require "ngx.ssl"
+
+            ssl.clear_certs()
+
+            local f = assert(io.open("t/cert/chain/chain.der"))
+            local cert_data = f:read("*a")
+            f:close()
+
+            local cert, err = ssl.parse_der_cert(cert_data)
+            if not cert then
+                ngx.log(ngx.ERR, "failed to parse pem cert: ", err)
+                return
+            end
+
+            local ok, err = ssl.set_cert(cert)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to set cert: ", err)
+                return
+            end
+
+            local f = assert(io.open("t/cert/chain/test-com.key.der"))
+            local pkey_data = f:read("*a")
+            f:close()
+
+            local pkey, err = ssl.parse_der_priv_key(pkey_data)
+            if not pkey then
+                ngx.log(ngx.ERR, "failed to parse pem key: ", err)
+                return
+            end
+
+            local ok, err = ssl.set_priv_key(pkey)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to set private key: ", err)
+                return
+            end
+        }
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block { ngx.status = 201 ngx.say("foo") ngx.exit(201) }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+    lua_ssl_trusted_certificate ../../cert/chain/root-ca.crt;
+    lua_ssl_verify_depth 3;
+
+    location /t {
+        content_by_lua_block {
+            do
+                local sock = ngx.socket.tcp()
+
+                sock:settimeout(3000)
+
+                local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+
+                ngx.say("connected: ", ok)
+
+                local sess, err = sock:sslhandshake(nil, "test.com", true)
+                if not sess then
+                    ngx.say("failed to do SSL handshake: ", err)
+                    return
+                end
+
+                ngx.say("ssl handshake: ", type(sess))
+
+                local req = "GET /foo HTTP/1.0\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+                local bytes, err = sock:send(req)
+                if not bytes then
+                    ngx.say("failed to send http request: ", err)
+                    return
+                end
+
+                ngx.say("sent http request: ", bytes, " bytes.")
+
+                while true do
+                    local line, err = sock:receive()
+                    if not line then
+                        -- ngx.say("failed to receive response status line: ", err)
+                        break
+                    end
+
+                    ngx.say("received: ", line)
+                end
+
+                local ok, err = sock:close()
+                ngx.say("close: ", ok, " ", err)
+            end  -- do
+            -- collectgarbage()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+connected: 1
+ssl handshake: cdata
+sent http request: 56 bytes.
+received: HTTP/1.1 201 Created
+received: Server: nginx
+received: Content-Type: text/plain
+received: Content-Length: 4
+received: Connection: close
+received:
+received: foo
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]
+[emerg]

--- a/t/ssl.t
+++ b/t/ssl.t
@@ -2838,6 +2838,8 @@ lua ssl server name: "test.com"
 [alert]
 [emerg]
 
+
+
 === TEST 29: parse PEM cert and key to cdata
 --- http_config
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";

--- a/t/stream/ssl.t
+++ b/t/stream/ssl.t
@@ -2140,3 +2140,108 @@ lua ssl server name: "test.com"
 [error]
 [alert]
 [emerg]
+
+
+=== TEST 27: parse DER cert and key to cdata
+--- stream_config
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        ssl_certificate_by_lua_block {
+            local ssl = require "ngx.ssl"
+
+            ssl.clear_certs()
+
+            local f = assert(io.open("t/cert/chain/chain.der"))
+            local cert_data = f:read("*a")
+            f:close()
+
+            local cert, err = ssl.parse_der_cert(cert_data)
+            if not cert then
+                ngx.log(ngx.ERR, "failed to parse DER cert: ", err)
+                return
+            end
+
+            local ok, err = ssl.set_cert(cert)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to set cert: ", err)
+                return
+            end
+
+            local f = assert(io.open("t/cert/chain/test-com.key.der"))
+            local pkey_data = f:read("*a")
+            f:close()
+
+            local pkey, err = ssl.parse_der_priv_key(pkey_data)
+            if not pkey then
+                ngx.log(ngx.ERR, "failed to parse DER key: ", err)
+                return
+            end
+
+            local ok, err = ssl.set_priv_key(pkey)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to set private key: ", err)
+                return
+            end
+        }
+        ssl_certificate ../../cert/test2.crt;
+        ssl_certificate_key ../../cert/test2.key;
+
+        return 'it works!\n';
+    }
+--- stream_server_config
+    lua_ssl_trusted_certificate ../../cert/chain/root-ca.crt;
+    lua_ssl_verify_depth 3;
+
+    content_by_lua_block {
+        do
+            local sock = ngx.socket.tcp()
+
+            sock:settimeout(3000)
+
+            local ok, err = sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local sess, err = sock:sslhandshake(nil, "test.com", true)
+            if not sess then
+                ngx.say("failed to do SSL handshake: ", err)
+                return
+            end
+
+            ngx.say("ssl handshake: ", type(sess))
+
+            while true do
+                local line, err = sock:receive()
+                if not line then
+                    -- ngx.say("failed to receive response status line: ", err)
+                    break
+                end
+
+                ngx.say("received: ", line)
+            end
+
+            local ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        end  -- do
+        -- collectgarbage()
+    }
+
+--- stream_response
+connected: 1
+ssl handshake: userdata
+received: it works!
+close: 1 nil
+
+--- error_log
+lua ssl server name: "test.com"
+
+--- no_error_log
+[error]
+[alert]
+[emerg]


### PR DESCRIPTION
This is the corresponding Lua side of https://github.com/openresty/lua-nginx-module/pull/2278 and https://github.com/openresty/stream-lua-nginx-module/pull/336 and should not be merged until those make it in.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
