### PR TITLE
optimize: Explicit requirement to use bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ LUA_INCLUDE_DIR ?= $(PREFIX)/include
 LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
 INSTALL ?= install
 
+SHELL := /bin/bash
+
 .PHONY: all test install
 
 all: ;


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.

echo in sh(/usr/bin/sh -> dash) in ubuntu does not accept the -e option of echo, so we explicit requirement to use bash
