### PR TITLE
bugfix: might get previous nextupdate value

### DIFF
--- a/lib/ngx/ocsp.lua
+++ b/lib/ngx/ocsp.lua
@@ -98,6 +98,7 @@ function _M.create_ocsp_request(certs, maxlen)
     return nil, ffi_str(errmsg[0])
 end
 
+local next_update_p = ffi_new("long[1]")
 
 function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
     local errbuf_size = max_errmsg_len
@@ -108,8 +109,6 @@ function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
 
     local sizep = get_size_ptr()
     sizep[0] = errbuf_size
-
-    local next_update_p = ffi_new("long[1]")
     
     local rc = C.ngx_http_lua_ffi_ssl_validate_ocsp_response(resp, #resp,
                                                              chain, #chain,
@@ -119,7 +118,9 @@ function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
     if rc == FFI_OK then
         local next_update = tonumber(next_update_p[0])
         if next_update == 0 then
-          next_update = nil
+            next_update = nil
+        else
+            next_update_p[0] = 0
         end
         return true, next_update
     end

--- a/lib/ngx/ocsp.lua
+++ b/lib/ngx/ocsp.lua
@@ -98,6 +98,7 @@ function _M.create_ocsp_request(certs, maxlen)
     return nil, ffi_str(errmsg[0])
 end
 
+
 local next_update_p = ffi_new("long[1]")
 
 function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
@@ -109,7 +110,9 @@ function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
 
     local sizep = get_size_ptr()
     sizep[0] = errbuf_size
-    
+
+    next_update_p[0] = 0
+
     local rc = C.ngx_http_lua_ffi_ssl_validate_ocsp_response(resp, #resp,
                                                              chain, #chain,
                                                              errbuf, sizep,
@@ -119,8 +122,6 @@ function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
         local next_update = tonumber(next_update_p[0])
         if next_update == 0 then
             next_update = nil
-        else
-            next_update_p[0] = 0
         end
         return true, next_update
     end

--- a/lib/ngx/ocsp.lua
+++ b/lib/ngx/ocsp.lua
@@ -99,8 +99,6 @@ function _M.create_ocsp_request(certs, maxlen)
 end
 
 
-local next_update_p = ffi_new("long[1]")
-
 function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
     local errbuf_size = max_errmsg_len
     if not errbuf_size then
@@ -111,6 +109,8 @@ function _M.validate_ocsp_response(resp, chain, max_errmsg_len)
     local sizep = get_size_ptr()
     sizep[0] = errbuf_size
 
+    local next_update_p = ffi_new("long[1]")
+    
     local rc = C.ngx_http_lua_ffi_ssl_validate_ocsp_response(resp, #resp,
                                                              chain, #chain,
                                                              errbuf, sizep,


### PR DESCRIPTION
For the ocsp response without nextUpdate value, it will get the previous nextUpdate value which is cached in the module-level lua ffi variable, this is not what we expected.

Maybe we should use function-level local variable instead?


I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
