### PR TITLE
tests: t/balancer.t: updated expected output, now respecting the maxi…

### DIFF
--- a/t/balancer.t
+++ b/t/balancer.t
@@ -700,7 +700,6 @@ github issue openresty/lua-nginx-module#693
 --- grep_error_log_out
 hello from balancer by lua!
 hello from balancer by lua!
-hello from balancer by lua!
 --- error_log eval
 qr/\[error] .*? upstream prematurely closed connection while reading response header from upstream/
 


### PR DESCRIPTION
…nt conflicts. Since changes by commit 94f55f7a4d493f627d545e890592c49a27c4a3bc openresty/lua-nginx-module.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
