### PR TITLE
bugfix: append new parameters to ngx_lua_ffi_balancer_set_current_pee…

### DIFF
--- a/lib/ngx/balancer.lua
+++ b/lib/ngx/balancer.lua
@@ -35,8 +35,8 @@ if subsystem == 'http' then
     ffi.cdef[[
     int ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
         const unsigned char *addr, size_t addr_len, int port,
-        const unsigned char *host, ssize_t host_len,
-        char **err);
+        char **err,
+        const unsigned char *host, ssize_t host_len);
 
     int ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
         unsigned long timeout, unsigned int max_requests, char **err);
@@ -162,9 +162,9 @@ if subsystem == "http" then
 
         local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr,
                                                          port,
+                                                         errmsg,
                                                          host,
-                                                         host and #host or 0,
-                                                         errmsg)
+                                                         host and #host or 0)
         if rc == FFI_OK then
             return true
         end


### PR DESCRIPTION
…r at function end.

Avoid inserting new parameters in the middle of the function to prevent core dumps when using old lua-resty-core with new lua-nginx-module.

Example stack trace:

```
Message: Process 1414245 (nginx) of user 1000 dumped core.

        Stack trace of thread 1414245:
        #0  0x00007ff596938285 __strlen_avx2 (libc.so.6 + 0x162285)
        #1  0x00007ff596f623d2 lj_cf_ffi_string (libluajit-5.1.so.2 + 0x523d2)
        #2  0x00007ff596f1bb4b lj_BC_FUNCC (libluajit-5.1.so.2 + 0xbb4b)
        #3  0x00007ff596f74223 lua_pcall (libluajit-5.1.so.2 + 0x64223)
        #4  0x00000000005044b7 n/a (/home/jiahao/work/org/lua-resty-core/work/nginx/sbin/nginx + 0x1044b7)
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
