### PR TITLE
bugfix: append new parameters to ngx_lua_ffi_ssl_verify_client at fun…

### DIFF
--- a/lib/ngx/ssl.lua
+++ b/lib/ngx/ssl.lua
@@ -100,7 +100,7 @@ if subsystem == 'http' then
     void ngx_http_lua_ffi_free_priv_key(void *cdata);
 
     int ngx_http_lua_ffi_ssl_verify_client(void *r,
-        void *client_certs, void *trusted_certs, int depth, char **err);
+        void *client_certs, int depth, char **err, void *trusted_certs);
 
     int ngx_http_lua_ffi_ssl_client_random(ngx_http_request_t *r,
         const unsigned char *out, size_t *outlen, char **err);
@@ -494,8 +494,8 @@ function _M.verify_client(client_certs, depth, trusted_certs)
         depth = -1
     end
 
-    local rc = ngx_lua_ffi_ssl_verify_client(r, client_certs, trusted_certs,
-                                             depth, errmsg)
+    local rc = ngx_lua_ffi_ssl_verify_client(r, client_certs, depth, errmsg,
+                                             trusted_certs)
     if rc == FFI_OK then
         return true
     end


### PR DESCRIPTION
…ction end.

Avoid inserting new parameters in the middle of the function to prevent core dumps when using old lua-resty-core with new lua-nginx-module.

Example stack trace:

```
Message: Process 2199905 (nginx) of user 1000 dumped core.

Stack trace of thread 2199905:
    #0  0x00007ffaf1e4b385 in OPENSSL_sk_num (st=st@entry=0xffffffff) at crypto/stack/stack.c:382
    #1  0x0000000000510aba in sk_X509_num (sk=0xffffffff) at /opt/ssl/include/openssl/x509.h:99
    #2  ngx_http_lua_ffi_ssl_verify_client (r=<optimized out>, client_certs=<optimized out>, trusted_certs=0xffffffff, depth=<optimized out>, err=0x0)
        at /home/jiahao/work/org/lua-nginx-module/src/ngx_http_lua_ssl_certby.c:1588
```

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
