### PR TITLE
tests: valgrind.suppress: added SSL-related valgrind.suppress entries.

### DIFF
--- a/valgrind.suppress
+++ b/valgrind.suppress
@@ -131,3 +131,51 @@
    fun:ssl_session_dup
    fun:tls_process_new_session_ticket
 }
+{
+    <insert_a_suppression_name_here>
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:CRYPTO_malloc
+    fun:ssl_session_dup
+    fun:tls_process_new_session_ticket
+    fun:ossl_statem_client_process_message
+    fun:read_state_machine
+    fun:state_machine
+    fun:ossl_statem_connect
+    fun:ssl3_read_bytes
+    fun:ssl3_read_internal
+    fun:ssl3_read
+    fun:ssl_read_internal
+    fun:SSL_read
+    fun:ngx_ssl_recv
+    fun:ngx_http_upstream_process_header
+    fun:ngx_http_upstream_handler
+    fun:ngx_epoll_process_events
+    fun:ngx_process_events_and_timers
+    fun:ngx_single_process_cycle
+    fun:main
+}
+{
+    <insert_a_suppression_name_here>
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:malloc
+    fun:CRYPTO_malloc
+    fun:CRYPTO_zalloc
+    fun:SSL_SESSION_new
+    fun:ssl_get_new_session
+    fun:tls_construct_client_hello
+    fun:write_state_machine
+    fun:state_machine
+    fun:ossl_statem_connect
+    fun:SSL_do_handshake
+    fun:ngx_ssl_handshake
+    fun:ngx_http_upstream_ssl_init_connection
+    fun:ngx_http_upstream_send_request_handler
+    fun:ngx_http_upstream_handler
+    fun:ngx_epoll_process_events
+    fun:ngx_process_events_and_timers
+    fun:ngx_single_process_cycle
+    fun:main
+}


### PR DESCRIPTION
Currently each upstream block leaks once. Temporarily ignore these leaks. TODO: Consider adding deallocation logic in nginx core later.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
