### PR TITLE
tests: Change TEST_NGINX_SERVER_SSL_PORT* to use random ports.

### DIFF
--- a/t/TestCore.pm
+++ b/t/TestCore.pm
@@ -3,11 +3,15 @@ package t::TestCore;
 use Test::Nginx::Socket::Lua -Base;
 use Cwd qw(cwd realpath abs_path);
 use File::Basename;
+use Test::Nginx::Util 'is_tcp_port_used';
 
 $ENV{TEST_NGINX_HOTLOOP} ||= 10;
 $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
-$ENV{TEST_NGINX_SERVER_SSL_PORT} ||= 23456;
 $ENV{TEST_NGINX_CERT_DIR} ||= dirname(realpath(abs_path(__FILE__)));
+
+sub get_unused_port ($);
+
+$ENV{TEST_NGINX_SERVER_SSL_PORT} ||= get_unused_port 23456;
 
 our $pwd = cwd();
 
@@ -41,6 +45,7 @@ our @EXPORT = qw(
     $lua_package_path
     $init_by_lua_block
     $HttpConfig
+    get_unused_port
 );
 
 add_block_preprocessor(sub {
@@ -50,5 +55,21 @@ add_block_preprocessor(sub {
         $block->set_value("http_config", $HttpConfig);
     }
 });
+
+sub get_unused_port ($) {
+    my $port = shift;
+
+    my $i = 1000;
+    srand($$); # reset the random seed
+    while ($i-- > 0) {
+        my $rand_port = $port + int(rand(65535 - $port));
+        if (!is_tcp_port_used $rand_port) {
+            #warn "found unused port $rand_port, pid $$\n";
+            return $rand_port;
+        }
+    }
+
+    die "no unused port available";
+}
 
 1;

--- a/t/balancer-keepalive-localaddr.t
+++ b/t/balancer-keepalive-localaddr.t
@@ -133,10 +133,10 @@ __DATA__
 127.0.0.11
 127.0.0.11
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
 $/
 
 
@@ -184,12 +184,12 @@ $/
 127.0.0.11
 127.0.0.11
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
 $/
 
 
@@ -236,10 +236,10 @@ $/
 127.0.0.10
 127.0.0.11
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
 $/
 
 
@@ -290,14 +290,14 @@ $/
 127.0.0.11
 127.0.0.10
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
 $/
 
 
@@ -343,10 +343,10 @@ $/
 127.0.0.11
 127.0.0.11
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.1:23456, name: test.com
-lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
 $/
 
 
@@ -392,10 +392,10 @@ $/
 127.0.0.11
 127.0.0.11
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
 $/
 
 
@@ -441,8 +441,8 @@ $/
 127.0.0.11:64321
 127.0.0.11:64321
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
-lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:23456, name: test.com
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive reusing connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
+lua balancer: keepalive saving connection [0-9A-F]+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.com
 $/

--- a/t/balancer-keepalive.t
+++ b/t/balancer-keepalive.t
@@ -15,7 +15,7 @@ if ($NginxV !~ m/built with OpenSSL/) {
     plan tests => repeat_each() * (blocks() * 4);
 }
 
-$ENV{TEST_NGINX_SERVER_SSL_PORT_2} = $ENV{TEST_NGINX_SERVER_SSL_PORT} + 1;
+$ENV{TEST_NGINX_SERVER_SSL_PORT_2} = get_unused_port $ENV{TEST_NGINX_SERVER_SSL_PORT} + 1;
 
 our $UpstreamSrvConfig = <<_EOC_;
     server {
@@ -175,16 +175,16 @@ SNI=two
 SNI=three
 SNI=three
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: one
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: one
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: two
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: two
-lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: two
-lua balancer: keepalive saving connection \S+, host: 127.0.0.2:23456, name: two
-lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: three
-lua balancer: keepalive saving connection \S+, host: 127.0.0.2:23456, name: three
-lua balancer: keepalive no free connection, host: 127.0.0.2:23457, name: three
-lua balancer: keepalive saving connection \S+, host: 127.0.0.2:23457, name: three$/
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive saving connection \S+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: three
+lua balancer: keepalive saving connection \S+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: three
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT_2}, name: three
+lua balancer: keepalive saving connection \S+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT_2}, name: three$/
 
 
 
@@ -224,12 +224,12 @@ SNI=one
 SNI=two
 SNI=three
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: one
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: one
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: two
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: two
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: three
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: three/
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: three
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: three/
 
 
 
@@ -274,16 +274,16 @@ SNI=two
 SNI=three
 SNI=three
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: one
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: one
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: two
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: two
-lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: two
-lua balancer: keepalive saving connection \S+, host: 127.0.0.2:23456, name: two
-lua balancer: keepalive no free connection, host: 127.0.0.2:23456, name: three
-lua balancer: keepalive saving connection \S+, host: 127.0.0.2:23456, name: three
-lua balancer: keepalive no free connection, host: 127.0.0.2:23457, name: three
-lua balancer: keepalive saving connection \S+, host: 127.0.0.2:23457, name: three$/
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive saving connection \S+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: three
+lua balancer: keepalive saving connection \S+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: three
+lua balancer: keepalive no free connection, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT_2}, name: three
+lua balancer: keepalive saving connection \S+, host: 127.0.0.2:$ENV{TEST_NGINX_SERVER_SSL_PORT_2}, name: three$/
 
 
 
@@ -319,10 +319,10 @@ lua balancer: keepalive saving connection \S+, host: 127.0.0.2:23457, name: thre
 SNI=one
 SNI=two
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: one
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: one
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: two
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: two
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
 $/
 
 
@@ -465,14 +465,14 @@ ssl_client_s_dn=.*?CN=test\.com.*? ssl_protocol=TLSv1\.1
 ssl_client_s_dn=.*?CN=test2\.com.*? ssl_protocol=TLSv1\.1
 ssl_client_s_dn=.*?CN=test2\.com.*? ssl_protocol=TLSv1\.1
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: test.crt
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: test.crt
-lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:23456, name: test.crt
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: test.crt
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: test2.crt
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: test2.crt
-lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:23456, name: test2.crt
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: test2.crt
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.crt
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.crt
+lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.crt
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test.crt
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test2.crt
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test2.crt
+lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test2.crt
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: test2.crt
 $/
 
 
@@ -681,14 +681,14 @@ bad argument #2 to 'enable_keepalive' (expected >= 0)
 --- response_body
 --- wait: 0.15
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:23456, name:\s
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive not saving connection \S+
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: $/
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: $/
 
 
 
@@ -723,11 +723,11 @@ lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: $/
     }
 --- response_body
 --- grep_error_log_out eval
-qr/\Alua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
-(lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
-){98}lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:23456, name:\s
+qr/\Alua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+(lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+){98}lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive not saving connection \S+
 \z/
 
@@ -798,11 +798,11 @@ lua balancer: keepalive not saving connection \S+
 --- response_body
 --- wait: 0.2
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive closing connection \S+
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive closing connection \S+$/
 
 
@@ -840,20 +840,20 @@ lua balancer: keepalive closing connection \S+$/
     }
 --- response_body
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive closing connection \S+
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive reusing connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive closing connection \S+
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: $/
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: $/
 
 
 
@@ -886,10 +886,10 @@ lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: $/
 --- wait: 0.15
 --- response_body
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name:\s
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive closing connection \S+
 lua balancer: keepalive closing connection \S+
 $/
@@ -924,9 +924,9 @@ $/
     }
 --- response_body
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive not saving connection \S+
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive not saving connection \S+
 $/
 
@@ -962,7 +962,7 @@ $/
 --- error_log eval
 qr/connect\(\) failed \(\d+: Connection refused\) while connecting to upstream/
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.3:23456, name:\s
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.3:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive not saving connection \S+$/
 
 
@@ -1003,7 +1003,7 @@ lua balancer: keepalive not saving connection \S+$/
 --- error_log
 upstream timed out
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive not saving connection \S+$/
 
 
@@ -1060,10 +1060,10 @@ lua balancer: keepalive not saving connection \S+$/
 --- no_error_log
 [crit]
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.3:23456, name:\s
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.3:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
 lua balancer: keepalive not saving connection \S+
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name:\s
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: $/
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name:\s
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: $/
 
 
 
@@ -1121,10 +1121,10 @@ SNI=two
 --- no_error_log
 [crit]
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive no free connection, host: 127.0.0.3:23456, name: one
+qr/^lua balancer: keepalive no free connection, host: 127.0.0.3:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
 lua balancer: keepalive not saving connection \S+
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: two
-lua balancer: keepalive saving connection \S+, host: 127.0.0.1:23456, name: two
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
+lua balancer: keepalive saving connection \S+, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
 $/
 
 
@@ -1209,12 +1209,12 @@ SNI=one
 --- grep_error_log eval: qr/(?:lua balancer: keepalive .*|(?:get|free) keepalive peer)/
 --- grep_error_log_out eval
 qr/^get keepalive peer
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: one
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: one
 free keepalive peer
 free keepalive peer
 lua balancer: keepalive not saving connection \S+
 get keepalive peer
-lua balancer: keepalive no free connection, host: 127.0.0.1:23456, name: two
+lua balancer: keepalive no free connection, host: 127.0.0.1:$ENV{TEST_NGINX_SERVER_SSL_PORT}, name: two
 get keepalive peer
 free keepalive peer
 free keepalive peer

--- a/t/stream/balancer-bind.t
+++ b/t/stream/balancer-bind.t
@@ -8,23 +8,25 @@ plan tests => repeat_each() * (blocks() * 4);
 
 $ENV{TEST_NGINX_LUA_PACKAGE_PATH} = "$t::TestCore::Stream::lua_package_path";
 
+$ENV{TEST_NGINX_UPSTREAM_PORT} ||= get_unused_port 12345;
+
 no_long_string();
 run_tests();
 
 __DATA__
 
-=== TEST 1: balancer 
+=== TEST 1: balancer
 --- stream_config
     lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
     upstream backend {
         server 0.0.0.1:1234 down;
         balancer_by_lua_block {
             local b = require "ngx.balancer"
-            assert(b.set_current_peer("127.0.0.1", 12345))
+            assert(b.set_current_peer("127.0.0.1", $TEST_NGINX_UPSTREAM_PORT))
         }
     }
     server {
-        listen 127.0.0.1:12345;
+        listen 127.0.0.1:$TEST_NGINX_UPSTREAM_PORT;
         content_by_lua_block {
             ngx.print(ngx.var.remote_addr, ":", ngx.var.remote_port)
         }
@@ -51,12 +53,12 @@ qr/127.0.0.1/,
         server 0.0.0.1:1234 down;
         balancer_by_lua_block {
             local b = require "ngx.balancer"
-            assert(b.set_current_peer("127.0.0.1", 12345))
+            assert(b.set_current_peer("127.0.0.1", $TEST_NGINX_UPSTREAM_PORT))
             assert(b.bind_to_local_addr("127.0.0.4"))
         }
     }
     server {
-        listen 127.0.0.1:12345;
+        listen 127.0.0.1:$TEST_NGINX_UPSTREAM_PORT;
         content_by_lua_block {
             ngx.print(ngx.var.remote_addr, ":", ngx.var.remote_port)
         }
@@ -83,12 +85,12 @@ qr/127.0.0.4/,
         server 0.0.0.1:1234 down;
         balancer_by_lua_block {
             local b = require "ngx.balancer"
-            assert(b.set_current_peer("127.0.0.1", 12345))
+            assert(b.set_current_peer("127.0.0.1", $TEST_NGINX_UPSTREAM_PORT))
             assert(b.bind_to_local_addr("127.0.0.8:23456"))
         }
     }
     server {
-        listen 127.0.0.1:12345;
+        listen 127.0.0.1:$TEST_NGINX_UPSTREAM_PORT;
         content_by_lua_block {
             ngx.print(ngx.var.remote_addr, ":", ngx.var.remote_port)
         }


### PR DESCRIPTION
Replace fixed ports with randomly assigned ports for `TEST_NGINX_SERVER_SSL_PORT*` variables. This prevents port conflicts when running tests in multiple processes.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
