### PR TITLE
feature : enhance ssl.get_shared_ssl_ciphers() for stream

### DIFF
--- a/lib/ngx/ssl.lua
+++ b/lib/ngx/ssl.lua
@@ -215,6 +215,9 @@ elseif subsystem == 'stream' then
 
     int ngx_stream_lua_ffi_ssl_client_random(ngx_stream_lua_request_t *r,
         unsigned char *out, size_t *outlen, char **err);
+
+    int ngx_stream_lua_ffi_req_shared_ssl_ciphers(ngx_stream_lua_request_t *r,
+        unsigned short *ciphers, unsigned short *nciphers, int filter_grease, char **err);
     ]]
 
     ngx_lua_ffi_ssl_set_der_certificate =
@@ -240,6 +243,8 @@ elseif subsystem == 'stream' then
     ngx_lua_ffi_free_priv_key = C.ngx_stream_lua_ffi_free_priv_key
     ngx_lua_ffi_ssl_verify_client = C.ngx_stream_lua_ffi_ssl_verify_client
     ngx_lua_ffi_ssl_client_random = C.ngx_stream_lua_ffi_ssl_client_random
+    ngx_lua_ffi_req_shared_ssl_ciphers =
+        C.ngx_stream_lua_ffi_req_shared_ssl_ciphers
 end
 
 

--- a/t/stream/ssl.t
+++ b/t/stream/ssl.t
@@ -8,7 +8,7 @@ use t::TestCore::Stream;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6 + 1);
+plan tests => repeat_each() * (blocks() * 6 + 2);
 
 no_long_string();
 #no_diff();
@@ -2335,3 +2335,94 @@ client-random length: 32
 [error]
 [alert]
 [emerg]
+
+
+
+=== TEST 29: get shared SSL ciphers
+--- stream_config
+    lua_package_path "$TEST_NGINX_LUA_PACKAGE_PATH";
+
+    server {
+        listen 127.0.0.1:$TEST_NGINX_RAND_PORT_1 ssl;
+        ssl_protocols TLSv1.2;
+        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384;
+
+        ssl_certificate_by_lua_block {
+            local ssl = require "ngx.ssl"
+            local ciphers, err = ssl.get_shared_ssl_ciphers()
+            if not err and ciphers then
+                ngx.log(ngx.INFO, "shared ciphers count: ", #ciphers)
+                local count = 0
+                for i, cipher_id in ipairs(ciphers) do
+                    count = count + 1
+                    ngx.log(ngx.INFO, string.format("%d: SHARED_CIPHER 0x%04x", i, cipher_id))
+                    if count >= 3 then  -- log only first 3 to avoid too much output
+                        break
+                    end
+                end
+            else
+                ngx.log(ngx.ERR, "failed to get shared ciphers: ", err)
+            end
+        }
+        ssl_certificate ../../cert/test.crt;
+        ssl_certificate_key ../../cert/test.key;
+
+        return 'it works!\n';
+    }
+--- stream_server_config
+    lua_ssl_trusted_certificate ../../cert/test.crt;
+    lua_ssl_protocols TLSv1.2;
+    lua_ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256;
+
+    content_by_lua_block {
+        do
+            local sock = ngx.socket.tcp()
+
+            sock:settimeout(3000)
+
+            local ok, err = sock:connect("127.0.0.1", $TEST_NGINX_RAND_PORT_1)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local sess, err = sock:sslhandshake(nil, nil, true)
+            if not sess then
+                ngx.say("failed to do SSL handshake: ", err)
+                return
+            end
+
+            ngx.say("ssl handshake: ", type(sess))
+
+            while true do
+                local line, err = sock:receive()
+                if not line then
+                    -- ngx.say("failed to receive response status line: ", err)
+                    break
+                end
+
+                ngx.say("received: ", line)
+            end
+
+            local ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        end  -- do
+        -- collectgarbage()
+    }
+
+--- stream_response
+connected: 1
+ssl handshake: userdata
+received: it works!
+close: 1 nil
+
+--- error_log eval
+[qr/shared ciphers count: \d+/,
+qr/1: SHARED_CIPHER 0x/]
+
+--- no_error_log
+[alert]
+[crit]
+[error]


### PR DESCRIPTION

### Summy

This pull request introduces a new feature to retrieve shared SSL ciphers in the `ngx_stream_lua_module` and includes corresponding tests. The main changes involve adding a new FFI function, updating the Lua API, and implementing a new test case to validate the feature.

### Related PR

Closed https://github.com/openresty/lua-resty-core/pull/505
https://github.com/openresty/lua-nginx-module/pull/1962
https://github.com/openresty/lua-nginx-module/pull/2424
https://github.com/openresty/stream-lua-nginx-module/pull/378

### New Feature: Shared SSL Ciphers Retrieval

* **FFI Function Addition**:
  - Added a new FFI function `ngx_stream_lua_ffi_req_shared_ssl_ciphers` in `lib/ngx/ssl.lua` to retrieve shared SSL ciphers. This function includes an option to filter GREASE values.

* **Lua API Update**:
  - Exposed the new FFI function as `ngx_lua_ffi_req_shared_ssl_ciphers` in the Lua API for the `ngx_stream_lua_module`.

### Testing Enhancements

* **Test Plan Update**:
  - Increased the planned test count in `t/stream/ssl.t` to accommodate the new test case.

* **New Test Case**:
  - Added a comprehensive test case (`TEST 29`) in `t/stream/ssl.t` to validate the retrieval of shared SSL ciphers. This test ensures the function works correctly by logging the shared cipher IDs and verifying the output in the error log.