### PR TITLE
optimize: avoid NYI for functions returning to lower frame

### DIFF
--- a/lib/resty/core/param.lua
+++ b/lib/resty/core/param.lua
@@ -12,6 +12,8 @@ local FFI_AGAIN = base.FFI_AGAIN
 local FFI_OK = base.FFI_OK
 local get_request = base.get_request
 local get_string_buf = base.get_string_buf
+local error = error
+local assert = assert
 local getmetatable = getmetatable
 local ngx = ngx
 local ngx_phase = ngx.get_phase
@@ -43,7 +45,8 @@ local function get_setby_param(r, idx)
         return nil
     end
 
-    return ffi_str(data_p[0], len_p[0])
+    local s = ffi_str(data_p[0], len_p[0])
+    return s
 end
 
 
@@ -56,14 +59,16 @@ local function get_body_filter_param(r, idx)
             local buf = get_string_buf(len_p[0])
             assert(C.ngx_http_lua_ffi_copy_body_filter_param_body(r, buf)
                    == FFI_OK)
-            return ffi_str(buf, len_p[0])
+            local s = ffi_str(buf, len_p[0])
+            return s
         end
 
         if len_p[0] == 0 then
             return ""
         end
 
-        return ffi_str(data_p[0], len_p[0])
+        local s = ffi_str(data_p[0], len_p[0])
+        return s
 
     elseif idx == 2 then
         local rc = C.ngx_http_lua_ffi_get_body_filter_param_eof(r)

--- a/lib/resty/core/var.lua
+++ b/lib/resty/core/var.lua
@@ -92,7 +92,8 @@ local function var_get(self, name)
     -- ngx.log(ngx.WARN, "rc = ", rc)
 
     if rc == 0 then -- NGX_OK
-        return ffi_str(value_ptr[0], value_len[0])
+        local s = ffi_str(value_ptr[0], value_len[0])
+        return s
     end
 
     if rc == -5 then  -- NGX_DECLINED


### PR DESCRIPTION
TRACE --- (87/5) var.lua:95 -- NYI: return to lower frame
TRACE --- (69/6) param.lua:66 -- NYI: return to lower frame

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
