### PR TITLE
chore: delete unnecessary resp arg according to get_tls1_version_str's signature

### DIFF
--- a/t/ssl.t
+++ b/t/ssl.t
@@ -1052,7 +1052,7 @@ lua ssl server name: "test.com"
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return
@@ -1129,7 +1129,7 @@ got TLS1 version: SSLv3,
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return
@@ -1206,7 +1206,7 @@ got TLS1 version: TLSv1,
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return
@@ -1283,7 +1283,7 @@ got TLS1 version: TLSv1.1,
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return
@@ -2290,7 +2290,7 @@ qr/subject=\/?C(?<eq>\s?=\s?)US(?<sep>\/|,\s)ST\k<eq>California\k<sep>L\k<eq>San
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return

--- a/t/stream/ssl.t
+++ b/t/stream/ssl.t
@@ -815,7 +815,7 @@ lua ssl server name: "test.com"
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return
@@ -882,7 +882,7 @@ got TLS1 version: SSLv3,
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return
@@ -948,7 +948,7 @@ got TLS1 version: TLSv1,
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return
@@ -1014,7 +1014,7 @@ got TLS1 version: TLSv1.1,
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return
@@ -1849,7 +1849,7 @@ qr/subject=\/?C(?<eq>\s?=\s?)US(?<sep>\/|,\s)ST\k<eq>California\k<sep>L\k<eq>San
         ssl_certificate_by_lua_block {
             local ssl = require "ngx.ssl"
 
-            local ver, err = ssl.get_tls1_version_str(resp)
+            local ver, err = ssl.get_tls1_version_str()
             if not ver then
                 ngx.log(ngx.ERR, "failed to get TLS1 version: ", err)
                 return


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
