### PR TITLE
bugfix: stream cosocket getsslctx() bound to wrong FFI symbol

### DIFF
--- a/lib/resty/core/socket.lua
+++ b/lib/resty/core/socket.lua
@@ -150,9 +150,9 @@ then
 ngx_lua_ffi_socket_getsslpointer =
     C.ngx_stream_lua_ffi_socket_tcp_get_ssl_pointer
 end
-if pcall(function() return C.ngx_stream_lua_ffi_socket_tcp_get_ssl_pointer end)
+if pcall(function() return C.ngx_stream_lua_ffi_socket_tcp_get_ssl_ctx end)
 then
-ngx_lua_ffi_socket_getsslctx = C.ngx_stream_lua_ffi_socket_tcp_get_ssl_pointer
+ngx_lua_ffi_socket_getsslctx = C.ngx_stream_lua_ffi_socket_tcp_get_ssl_ctx
 end
 
 if pcall(function()


### PR DESCRIPTION
## Summary

In `lib/resty/core/socket.lua`, the stream branch binds `ngx_lua_ffi_socket_getsslctx` to `ngx_stream_lua_ffi_socket_tcp_get_ssl_pointer` — clearly a copy/paste from the `getsslpointer` block right above it. The probing `pcall` also references `_get_ssl_pointer` instead of `_get_ssl_ctx`.

```lua
if pcall(function() return C.ngx_stream_lua_ffi_socket_tcp_get_ssl_pointer end)
then
ngx_lua_ffi_socket_getsslctx = C.ngx_stream_lua_ffi_socket_tcp_get_ssl_pointer
end
```

Compare with the http branch (lines 103-104), which correctly probes and binds `_get_ssl_ctx`.

## Impact

`stream-lua-nginx-module` exports both `ngx_stream_lua_ffi_socket_tcp_get_ssl_pointer` (returns `SSL *`) and `ngx_stream_lua_ffi_socket_tcp_get_ssl_ctx` (returns `SSL_CTX *`). With the current binding, stream `cosocket:getsslctx()` actually returns an `SSL *` while callers treat it as `SSL_CTX *` — undefined behavior / potential segfault when callers dereference fields at `SSL_CTX` offsets.

## Fix

Bind to `ngx_stream_lua_ffi_socket_tcp_get_ssl_ctx`, mirroring the http branch. The C declaration for `_get_ssl_ctx` is already present in the stream `ffi.cdef` block (line 136), so no additional declaration is needed.

## Test plan

- [ ] Verify stream `cosocket:getsslctx()` returns a value usable as `SSL_CTX *` (e.g., `SSL_CTX_set_*` calls).
- [ ] Existing http `getsslctx` tests continue to pass.