### PR TITLE
bugfix: check sslhandshake result on immediate OK

### DIFF
--- a/lib/resty/core/socket.lua
+++ b/lib/resty/core/socket.lua
@@ -424,52 +424,50 @@ local function sslhandshake(cosocket, reused_session, server_name, ssl_verify,
         error("no request ctx found", 2)
     end
 
-    if rc == FFI_OK then
-        if reused_session == false then
-            return true
+    if rc == FFI_ERROR then
+        if openssl_error_code[0] ~= 0 then
+            return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
         end
 
-        rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
-                 session_ptr, errmsg, openssl_error_code)
+        return nil, ffi_str(errmsg[0])
     end
 
-    while true do
-        if rc == FFI_ERROR then
-            if openssl_error_code[0] ~= 0 then
-                return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
-            end
+    if rc == FFI_DONE then
+        return reused_session
+    end
 
-            return nil, ffi_str(errmsg[0])
-        end
+    local res
 
-        if rc == FFI_DONE then
-            return reused_session
-        end
-
-        if rc == FFI_OK then
-            if reused_session == false then
-                return true
-            end
-
-            rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
-                     session_ptr, errmsg, openssl_error_code)
-
-            assert(rc == FFI_OK)
-
-            if session_ptr[0] == nil then
-                return session_ptr[0]
-            end
-
-            return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
-        end
-
+    if rc == FFI_OK then
+        res = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
+                session_ptr, errmsg, openssl_error_code)
+    else
         assert(rc == FFI_AGAIN)
 
         co_yield()
 
-        rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
-                 session_ptr, errmsg, openssl_error_code)
+        res = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
+                session_ptr, errmsg, openssl_error_code)
     end
+
+    if res == FFI_ERROR then
+        if openssl_error_code[0] ~= 0 then
+            return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
+        end
+        return nil, ffi_str(errmsg[0])
+    end
+
+    assert(res == FFI_OK)
+
+    if reused_session == false then
+        return true
+    end
+
+    if session_ptr[0] == nil then
+        return session_ptr[0]
+    end
+
+    return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
 end
 
 


### PR DESCRIPTION
This patch fixes the immediate `FFI_OK` path in `tcpsock:sslhandshake()`.

## The bug

Currently `sslhandshake()` treats the initial `FFI_OK` return from
`ngx_http_lua_ffi_socket_tcp_sslhandshake()` as the final successful result when
`reused_session == false`:

```lua
rc = ngx_http_lua_ffi_socket_tcp_sslhandshake(...)

if rc == FFI_OK then
    if reused_session == false then
        return true
    end

    rc = ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(...)
end
```

This skips `ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result()` for the
`reused_session == false` case.

## Why this is wrong

The first FFI call result and the final SSL handshake result are not the same
thing.

`ngx_http_lua_ffi_socket_tcp_sslhandshake()` internally calls
`ngx_ssl_handshake(c)`, which returns `NGX_OK` when the TLS protocol handshake
completes successfully. This means the peer presented a valid certificate that
completed the TLS key exchange. The certificate was correctly formatted, signed
by its issuer, and the TLS record layer handshake finished.

**However**, after `ngx_ssl_handshake(c)` returns, the ngx_lua handler calls
`SSL_get_verify_result()` to check whether the certificate chain is trusted
according to the configured CA store. If the peer's CA is not in the trusted
store, the handler records the verify error:

```text
u->error_ret = "unable to verify the first certificate"
u->openssl_error_code_ret = 21
```

But the outer C code only checks the original `rc` from `ngx_ssl_handshake()`:

```c
rc = ngx_ssl_handshake(c);

ngx_http_lua_ssl_handshake_handler(c);

if (rc == NGX_ERROR) {
    // rc is NGX_OK, so this is skipped
    return NGX_ERROR;
}

return NGX_OK;  // FFI_OK to Lua — but u->error_ret is set!
```

The C FFI returns `FFI_OK` even though certificate verification recorded a
failure. In Lua, the immediate `FFI_OK` path returns `true` directly, so the
caller believes TLS succeeded. The next socket operation then fails with a
misleading error (e.g. "closed" on write) instead of reporting the original
certificate verification failure.

## Visual comparison

Old flow:

```text
Lua sslhandshake()                  C
      |
      v
FFI: sslhandshake() ──────────► ngx_ssl_handshake(c) → NGX_OK
                                     |
                                     v
                                handler: SSL_get_verify_result() → 21
                                     |
                                     v
                                u->error_ret = "unable to verify..."
                                     |
                                     v
                                if (rc == NGX_ERROR) ... no
                                     |
                                     v
      ◄──────────────────────── return NGX_OK / FFI_OK
      |
      v
reused_session == false?
      |
      v
return true           ◄── final result never checked, error lost
      |
      v
caller believes TLS ok → sock:send() → "closed"
```

Fixed flow:

```text
Lua sslhandshake()                  C
      |
      v
FFI: sslhandshake() ──────────► same as above, returns FFI_OK
      |
      v
FFI: get_result() ────────────► u->error_ret != NULL → NGX_ERROR
      |
      v
return nil, "21: unable to verify the first certificate"
```

## The patch

```lua
rc = ngx_http_lua_ffi_socket_tcp_sslhandshake(...)

if rc == FFI_ERROR then
    return nil, err
end

if rc == FFI_DONE then
    return reused_session
end

local res

if rc == FFI_OK then
    res = ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(...)
else
    assert(rc == FFI_AGAIN)
    co_yield()
    res = ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(...)
end

if res == FFI_ERROR then
    return nil, ssl_err
end

assert(res == FFI_OK)

return true or session
```

Two changes:
1. The immediate `FFI_OK` path now always reads the final result via
   `ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result()`.
2. Uses separate variables (`rc` for the first FFI call state, `res` for the
   final handshake result) so the two meanings do not overlap.

This keeps the existing async behavior unchanged, but makes the immediate
`FFI_OK` path follow the same final-result check as the resumed `FFI_AGAIN`
path.

#500 has not been completely resolved the https://github.com/openresty/lua-resty-core/issues/499

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.