### PR TITLE
bugfix: sslhandshake read error details on immediate FFI_ERROR

### DIFF
--- a/lib/resty/core/socket.lua
+++ b/lib/resty/core/socket.lua
@@ -424,52 +424,68 @@ local function sslhandshake(cosocket, reused_session, server_name, ssl_verify,
         error("no request ctx found", 2)
     end
 
+    local res
+
+    if rc == FFI_ERROR then
+        res = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
+                  session_ptr, errmsg, openssl_error_code)
+
+        assert(res == FFI_ERROR)
+
+        if openssl_error_code[0] ~= 0 then
+            return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
+        end
+
+        return nil, ffi_str(errmsg[0])
+    end
+
+    if rc == FFI_DONE then
+        return reused_session
+    end
+
     if rc == FFI_OK then
         if reused_session == false then
             return true
         end
 
-        rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
-                 session_ptr, errmsg, openssl_error_code)
+        res = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
+                  session_ptr, errmsg, openssl_error_code)
+
+        assert(res == FFI_OK)
+
+        if session_ptr[0] == nil then
+            return session_ptr[0]
+        end
+
+        return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
     end
 
-    while true do
-        if rc == FFI_ERROR then
-            if openssl_error_code[0] ~= 0 then
-                return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
-            end
+    assert(rc == FFI_AGAIN)
 
-            return nil, ffi_str(errmsg[0])
+    co_yield()
+
+    res = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
+              session_ptr, errmsg, openssl_error_code)
+
+    if res == FFI_ERROR then
+        if openssl_error_code[0] ~= 0 then
+            return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
         end
 
-        if rc == FFI_DONE then
-            return reused_session
-        end
-
-        if rc == FFI_OK then
-            if reused_session == false then
-                return true
-            end
-
-            rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
-                     session_ptr, errmsg, openssl_error_code)
-
-            assert(rc == FFI_OK)
-
-            if session_ptr[0] == nil then
-                return session_ptr[0]
-            end
-
-            return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
-        end
-
-        assert(rc == FFI_AGAIN)
-
-        co_yield()
-
-        rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
-                 session_ptr, errmsg, openssl_error_code)
+        return nil, ffi_str(errmsg[0])
     end
+
+    assert(res == FFI_OK)
+
+    if reused_session == false then
+        return true
+    end
+
+    if session_ptr[0] == nil then
+        return session_ptr[0]
+    end
+
+    return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
 end
 
 


### PR DESCRIPTION
With the C side now returning FFI_ERROR instead of FFI_OK when u->error_ret is set after an immediate handshake, the early FFI_OK path is removed.  Added get_sslhandshake_result() in the FFI_ERROR branch so errmsg and openssl_error_code are populated when the error comes from the first call rather than from an async resume.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
