### PR TITLE
bugfix: remove sslhandshake result assert for pre-handshake errors.

### DIFF
--- a/lib/resty/core/socket.lua
+++ b/lib/resty/core/socket.lua
@@ -424,13 +424,9 @@ local function sslhandshake(cosocket, reused_session, server_name, ssl_verify,
         error("no request ctx found", 2)
     end
 
-    local res
-
     if rc == FFI_ERROR then
-        res = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
+        C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
                   session_ptr, errmsg, openssl_error_code)
-
-        assert(res == FFI_ERROR)
 
         if openssl_error_code[0] ~= 0 then
             return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
@@ -442,6 +438,8 @@ local function sslhandshake(cosocket, reused_session, server_name, ssl_verify,
     if rc == FFI_DONE then
         return reused_session
     end
+
+    local res
 
     if rc == FFI_OK then
         if reused_session == false then


### PR DESCRIPTION
When `tcpsock:sslhandshake()` fails before the actual SSL handshake starts, `ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result()` may return `FFI_OK` while still providing the OpenSSL error details.

One example is a client private key setup failure. In that path, `rc` is `FFI_ERROR`, but `u->error_ret` is not set, so `ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result` would return `FFI_OK`. The existing `assert(res == FFI_ERROR)` turns this expected error-reporting path into an assertion failure.

This patch removes the assertion so Lua can return the original SSL error to the caller.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-resty-core project.
